### PR TITLE
fix: implement -i flag for compress and convert commands

### DIFF
--- a/internal/compress/audio.go
+++ b/internal/compress/audio.go
@@ -45,7 +45,13 @@ func Audio(opts AudioOptions) error {
 		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
 
 		if opts.DryRun {
-			ui.Message.Infof("[dry-run] Would compress %s -> %s (bitrate=%s)", file, out, bitrate)
+			ui.Message.Infof(
+				"[dry-run] Would compress %s -> %s (bitrate=%s)%s",
+				file,
+				out,
+				bitrate,
+				util.InPlaceHint(opts.InPlace),
+			)
 
 			continue
 		}
@@ -82,6 +88,10 @@ func Audio(opts AudioOptions) error {
 				util.HumanSize(newSize),
 				ratio,
 			)
+
+			if opts.InPlace {
+				util.MaybeInPlace(out, file)
+			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)
 			ui.Message.Mutedf("ffmpeg: %s", string(output))

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -51,11 +51,12 @@ func Image(opts ImageOptions) error {
 
 		if opts.DryRun {
 			ui.Message.Infof(
-				"[dry-run] Would compress %s -> %s (format=%s, quality=%d)",
+				"[dry-run] Would compress %s -> %s (format=%s, quality=%d)%s",
 				file,
 				out,
 				ext,
 				qualityVal,
+				util.InPlaceHint(opts.InPlace),
 			)
 
 			continue
@@ -109,6 +110,10 @@ func Image(opts ImageOptions) error {
 				util.HumanSize(newSize),
 				ratio,
 			)
+
+			if opts.InPlace {
+				util.MaybeInPlace(out, file)
+			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)
 		}

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -48,11 +48,12 @@ func Video(opts VideoOptions) error {
 
 		if opts.DryRun {
 			ui.Message.Infof(
-				"[dry-run] Would compress %s -> %s (crf=%d, preset=%s)",
+				"[dry-run] Would compress %s -> %s (crf=%d, preset=%s)%s",
 				file,
 				out,
 				crf,
 				preset,
+				util.InPlaceHint(opts.InPlace),
 			)
 
 			continue
@@ -94,6 +95,10 @@ func Video(opts VideoOptions) error {
 				util.HumanSize(newSize),
 				ratio,
 			)
+
+			if opts.InPlace {
+				util.MaybeInPlace(out, file)
+			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)
 			ui.Message.Mutedf("ffmpeg: %s", string(output))

--- a/internal/convert/audio.go
+++ b/internal/convert/audio.go
@@ -17,6 +17,7 @@ type AudioOptions struct {
 	Target    string
 	Quality   string
 	OutputDir string
+	InPlace   bool
 	DryRun    bool
 }
 
@@ -65,7 +66,12 @@ func Audio(opts AudioOptions) error {
 		)
 
 		if opts.DryRun {
-			ui.Message.Infof("[dry-run] Would convert %s -> %s", file, out)
+			ui.Message.Infof(
+				"[dry-run] Would convert %s -> %s%s",
+				file,
+				out,
+				util.InPlaceHint(opts.InPlace),
+			)
 
 			continue
 		}
@@ -93,6 +99,10 @@ func Audio(opts AudioOptions) error {
 				util.HumanSize(origSize),
 				util.HumanSize(util.FileSize(out)),
 			)
+
+			if opts.InPlace {
+				util.RemoveInPlace(file)
+			}
 		} else {
 			ui.Message.Errorf("Conversion failed: %s", file)
 			ui.Message.Mutedf("ffmpeg: %s", string(output))

--- a/internal/convert/image.go
+++ b/internal/convert/image.go
@@ -73,7 +73,12 @@ func Image(opts ImageOptions) error {
 		)
 
 		if opts.DryRun {
-			ui.Message.Infof("[dry-run] Would convert %s -> %s", file, out)
+			ui.Message.Infof(
+				"[dry-run] Would convert %s -> %s%s",
+				file,
+				out,
+				util.InPlaceHint(opts.InPlace),
+			)
 
 			continue
 		}
@@ -118,6 +123,10 @@ func Image(opts ImageOptions) error {
 				util.HumanSize(origSize),
 				util.HumanSize(util.FileSize(out)),
 			)
+
+			if opts.InPlace {
+				util.RemoveInPlace(file)
+			}
 		} else {
 			ui.Message.Errorf("Conversion failed: %s", file)
 		}

--- a/internal/convert/video.go
+++ b/internal/convert/video.go
@@ -61,7 +61,12 @@ func Video(opts VideoOptions) error {
 		)
 
 		if opts.DryRun {
-			ui.Message.Infof("[dry-run] Would convert %s -> %s", file, out)
+			ui.Message.Infof(
+				"[dry-run] Would convert %s -> %s%s",
+				file,
+				out,
+				util.InPlaceHint(opts.InPlace),
+			)
 
 			continue
 		}
@@ -89,6 +94,10 @@ func Video(opts VideoOptions) error {
 				util.HumanSize(origSize),
 				util.HumanSize(util.FileSize(out)),
 			)
+
+			if opts.InPlace {
+				util.RemoveInPlace(file)
+			}
 		} else {
 			ui.Message.Errorf("Conversion failed: %s", file)
 			ui.Message.Mutedf("ffmpeg: %s", string(output))

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -111,6 +111,12 @@ func MaybeInPlace(compressed, original string) {
 	}
 }
 
+// RemoveInPlace deletes the original file after a successful in-place conversion
+// where the output has a different extension than the input.
+func RemoveInPlace(original string) {
+	_ = os.Remove(original)
+}
+
 // FileExists reports whether the given path exists.
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
@@ -145,4 +151,14 @@ func EnsureDir(path string) error {
 	}
 
 	return nil
+}
+
+// InPlaceHint returns " (in-place)" when inPlace is true, or "" otherwise.
+// Use it to append an in-place indicator to dry-run messages.
+func InPlaceHint(inPlace bool) string {
+	if inPlace {
+		return " (in-place)"
+	}
+
+	return ""
 }

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -165,17 +165,80 @@ func TestEnsureDir(t *testing.T) {
 
 // TestMaybeInPlace tests MaybeInPlace.
 func TestMaybeInPlace(t *testing.T) {
+	// When compressed doesn't exist, original should remain untouched.
 	dir := t.TempDir()
 	orig := filepath.Join(dir, "original.txt")
 	comp := filepath.Join(dir, "compressed.txt")
 
 	//nolint:errcheck
-	os.WriteFile(orig, nil, 0o644)
+	os.WriteFile(orig, []byte("original"), 0o644)
 	MaybeInPlace(comp, orig)
 
-	_, err := os.Stat(orig)
+	data, err := os.ReadFile(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-	if os.IsNotExist(err) {
-		t.Error("MaybeInPlace should not rename when compressed doesn't exist")
+	if string(data) != "original" {
+		t.Errorf("MaybeInPlace without compressed: got %q; want \"original\"", string(data))
+	}
+}
+
+// TestMaybeInPlaceRename tests that MaybeInPlace renames the compressed file to the original.
+func TestMaybeInPlaceRename(t *testing.T) {
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "video.mp4")
+	comp := filepath.Join(dir, "video-small.mp4")
+
+	//nolint:errcheck
+	os.WriteFile(orig, []byte("old"), 0o644)
+	//nolint:errcheck
+	os.WriteFile(comp, []byte("compressed"), 0o644)
+
+	MaybeInPlace(comp, orig)
+
+	if FileExists(comp) {
+		t.Error("MaybeInPlace should remove the compressed file after rename")
+	}
+
+	data, err := os.ReadFile(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(data) != "compressed" {
+		t.Errorf("MaybeInPlace: original should contain compressed content; got %q", string(data))
+	}
+}
+
+// TestRemoveInPlace tests RemoveInPlace.
+func TestRemoveInPlace(t *testing.T) {
+	dir := t.TempDir()
+	orig := filepath.Join(dir, "video.mov")
+
+	//nolint:errcheck
+	os.WriteFile(orig, []byte("old"), 0o644)
+
+	RemoveInPlace(orig)
+
+	if FileExists(orig) {
+		t.Error("RemoveInPlace should delete the original file")
+	}
+}
+
+// TestRemoveInPlaceNonexistent tests that RemoveInPlace doesn't panic on missing files.
+func TestRemoveInPlaceNonexistent(t *testing.T) {
+	// Should not panic even if the file doesn't exist.
+	RemoveInPlace("/nonexistent/file.txt")
+}
+
+// TestInPlaceHint tests InPlaceHint.
+func TestInPlaceHint(t *testing.T) {
+	if got := InPlaceHint(true); got != " (in-place)" {
+		t.Errorf("InPlaceHint(true) = %q; want \" (in-place)\"", got)
+	}
+
+	if got := InPlaceHint(false); got != "" {
+		t.Errorf("InPlaceHint(false) = %q; want \"\"", got)
 	}
 }


### PR DESCRIPTION
The -i (--in-place) flag was accepted by all commands but never used.
This fix ensures:

- Compress commands: replace original file with compressed version
  via util.MaybeInPlace()
- Convert commands: delete original and keep converted output with
  correct extension via util.RemoveInPlace()
- Dry-run messages now show (in-place) when -i is active
- Added util.InPlaceHint() helper to DRY up the pattern
- Added tests for MaybeInPlace, RemoveInPlace, and InPlaceHint
