### PR TITLE
fix: bug fixes and code quality improvements

### DIFF
--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/y3owk1n/uts/internal/ui"
+	"github.com/y3owk1n/uts/internal/util"
 )
 
 // ExtractOptions represents options for archive extraction.
@@ -27,7 +28,7 @@ type ListOptions struct {
 // Extract extracts archive files.
 func Extract(opts ExtractOptions) error {
 	for _, file := range opts.Files {
-		if !fileExists(file) {
+		if !util.FileExists(file) {
 			ui.Message.Warnf("File not found: %s", file)
 
 			continue
@@ -54,40 +55,22 @@ func Extract(opts ExtractOptions) error {
 		spinner.Start()
 
 		var err error
-		switch ext {
-		case "zip":
-			if !hasTool("unzip") {
-				spinner.Stop()
-				ui.Message.Errorf("unzip not found — install: brew install unzip")
 
-				continue
-			}
-
-			err = exec.CommandContext(context.Background(), "unzip", "-qo", file, "-d", outDir).
-				Run()
-		case "tar":
-			err = exec.CommandContext(context.Background(), "tar", "xf", file, "-C", outDir).Run()
-		case "gz", "tgz":
-			err = exec.CommandContext(context.Background(), "tar", "xzf", file, "-C", outDir).Run()
-		case "zst", "zstd":
-			if !hasTool("zstd") {
+		// Handle compound extensions (.tar.zst, .tar.bz2, .tar.xz) before simple ones
+		// because filepath.Ext only returns the last extension.
+		switch {
+		case strings.HasSuffix(strings.ToLower(file), ".tar.zst"):
+			if !util.HasTool("zstd") {
 				spinner.Stop()
 				ui.Message.Errorf("zstd not found — install: brew install zstd")
 
 				continue
 			}
 
-			decomp := exec.CommandContext(
-				context.Background(),
-				"zstd",
-				"-d",
-				file,
-				"--force",
-				"-o",
-				file+".unpacked",
-			)
+			tmp := file + ".tmp"
 
-			err = decomp.Run()
+			err = exec.CommandContext(context.Background(), "zstd", "-d", file, "--force", "-o", tmp).
+				Run()
 			if err != nil {
 				spinner.Stop()
 				ui.Message.Errorf("zstd decompression failed: %s", file)
@@ -95,28 +78,93 @@ func Extract(opts ExtractOptions) error {
 				continue
 			}
 
-			err = exec.CommandContext(context.Background(), "tar", "xf", file+".unpacked", "-C", outDir).
-				Run()
-			_ = os.Remove(file + ".unpacked")
-		case "xz", "txz":
-			err = exec.CommandContext(context.Background(), "xz", "-dk", file).Run()
-			if err == nil {
-				err = exec.CommandContext(context.Background(), "tar", "xf", strings.TrimSuffix(file, ".xz"), "-C", outDir).
-					Run()
-				_ = os.Remove(strings.TrimSuffix(file, ".xz"))
-			}
-		case "bz2", "tbz2":
+			err = exec.CommandContext(context.Background(), "tar", "xf", tmp, "-C", outDir).Run()
+			_ = os.Remove(tmp)
+		case strings.HasSuffix(strings.ToLower(file), ".tar.bz2"):
+			tmp := strings.TrimSuffix(file, ".bz2")
+
 			err = exec.CommandContext(context.Background(), "bunzip2", "-k", file).Run()
 			if err == nil {
-				err = exec.CommandContext(context.Background(), "tar", "xf", strings.TrimSuffix(file, ".bz2"), "-C", outDir).
+				err = exec.CommandContext(context.Background(), "tar", "xf", tmp, "-C", outDir).
 					Run()
-				_ = os.Remove(strings.TrimSuffix(file, ".bz2"))
+				_ = os.Remove(tmp)
+			}
+		case strings.HasSuffix(strings.ToLower(file), ".tar.xz"):
+			tmp := strings.TrimSuffix(file, ".xz")
+
+			err = exec.CommandContext(context.Background(), "xz", "-dk", file).Run()
+			if err == nil {
+				err = exec.CommandContext(context.Background(), "tar", "xf", tmp, "-C", outDir).
+					Run()
+				_ = os.Remove(tmp)
 			}
 		default:
-			spinner.Stop()
-			ui.Message.Errorf("Unsupported archive: .%s", ext)
+			switch ext {
+			case "zip":
+				if !util.HasTool("unzip") {
+					spinner.Stop()
+					ui.Message.Errorf("unzip not found — install: brew install unzip")
 
-			continue
+					continue
+				}
+
+				err = exec.CommandContext(context.Background(), "unzip", "-qo", file, "-d", outDir).
+					Run()
+			case "tar":
+				err = exec.CommandContext(context.Background(), "tar", "xf", file, "-C", outDir).
+					Run()
+			case "gz", "tgz":
+				err = exec.CommandContext(context.Background(), "tar", "xzf", file, "-C", outDir).
+					Run()
+			case "zst", "zstd":
+				if !util.HasTool("zstd") {
+					spinner.Stop()
+					ui.Message.Errorf("zstd not found — install: brew install zstd")
+
+					continue
+				}
+
+				decomp := exec.CommandContext(
+					context.Background(),
+					"zstd",
+					"-d",
+					file,
+					"--force",
+					"-o",
+					file+".unpacked",
+				)
+
+				err = decomp.Run()
+				if err != nil {
+					spinner.Stop()
+					ui.Message.Errorf("zstd decompression failed: %s", file)
+
+					continue
+				}
+
+				err = exec.CommandContext(context.Background(), "tar", "xf", file+".unpacked", "-C", outDir).
+					Run()
+				_ = os.Remove(file + ".unpacked")
+			case "xz", "txz":
+				err = exec.CommandContext(context.Background(), "xz", "-dk", file).Run()
+				if err == nil {
+					err = exec.CommandContext(context.Background(), "tar", "xf", strings.TrimSuffix(file, ".xz"), "-C", outDir).
+						Run()
+					_ = os.Remove(strings.TrimSuffix(file, ".xz"))
+				}
+			case "bz2", "tbz2":
+				err = exec.CommandContext(context.Background(), "bunzip2", "-k", file).Run()
+				if err == nil {
+					err = exec.CommandContext(context.Background(), "tar", "xf", strings.TrimSuffix(file, ".bz2"), "-C", outDir).
+						Run()
+					_ = os.Remove(strings.TrimSuffix(file, ".bz2"))
+				}
+			default:
+				spinner.Stop()
+				ui.Message.Errorf("Unsupported archive: .%s", ext)
+
+				continue
+			}
 		}
 
 		spinner.Stop()
@@ -134,7 +182,7 @@ func Extract(opts ExtractOptions) error {
 // List lists the contents of archive files.
 func List(opts ListOptions) error {
 	for _, file := range opts.Files {
-		if !fileExists(file) {
+		if !util.FileExists(file) {
 			ui.Message.Warnf("File not found: %s", file)
 
 			continue
@@ -151,39 +199,87 @@ func List(opts ListOptions) error {
 			output []byte
 			err    error
 		)
-		switch ext {
-		case "zip":
-			if !hasTool("unzip") {
-				spinner.Stop()
-				ui.Message.Errorf("unzip not found — install: brew install unzip")
-
-				continue
-			}
-
-			output, err = exec.CommandContext(context.Background(), "unzip", "-l", file).Output()
-		case "tar":
-			output, err = exec.CommandContext(context.Background(), "tar", "tf", file).Output()
-		case "gz", "tgz":
-			output, err = exec.CommandContext(context.Background(), "tar", "tzf", file).Output()
-		case "zst", "zstd":
-			if hasTool("zstd") {
-				output, err = exec.CommandContext(context.Background(), "zstd", "-dc", file).
-					Output()
-			} else {
+		// Handle compound extensions (.tar.zst, .tar.bz2, .tar.xz) before simple ones
+		// because filepath.Ext only returns the last extension.
+		switch {
+		case strings.HasSuffix(strings.ToLower(file), ".tar.zst"):
+			if !util.HasTool("zstd") {
 				spinner.Stop()
 				ui.Message.Errorf("zstd not found — install: brew install zstd")
 
 				continue
 			}
-		case "xz", "txz":
-			output, err = exec.CommandContext(context.Background(), "xz", "-dc", file).Output()
-		case "bz2", "tbz2":
-			output, err = exec.CommandContext(context.Background(), "bzip2", "-dc", file).Output()
-		default:
-			spinner.Stop()
-			ui.Message.Errorf("Unsupported archive: .%s", ext)
 
-			continue
+			tmp := file + ".tmp"
+
+			err2 := exec.CommandContext(context.Background(), "zstd", "-d", file, "--force", "-o", tmp).
+				Run()
+			if err2 != nil {
+				spinner.Stop()
+				ui.Message.Errorf("zstd decompression failed: %s", file)
+
+				continue
+			}
+
+			output, err = exec.CommandContext(context.Background(), "tar", "tf", tmp).Output()
+			_ = os.Remove(tmp)
+		case strings.HasSuffix(strings.ToLower(file), ".tar.bz2"):
+			tmp := strings.TrimSuffix(file, ".bz2")
+
+			err2 := exec.CommandContext(context.Background(), "bunzip2", "-k", file).Run()
+			if err2 == nil {
+				output, err = exec.CommandContext(context.Background(), "tar", "tf", tmp).Output()
+				_ = os.Remove(tmp)
+			} else {
+				err = err2
+			}
+		case strings.HasSuffix(strings.ToLower(file), ".tar.xz"):
+			tmp := strings.TrimSuffix(file, ".xz")
+
+			err2 := exec.CommandContext(context.Background(), "xz", "-dk", file).Run()
+			if err2 == nil {
+				output, err = exec.CommandContext(context.Background(), "tar", "tf", tmp).Output()
+				_ = os.Remove(tmp)
+			} else {
+				err = err2
+			}
+		default:
+			switch ext {
+			case "zip":
+				if !util.HasTool("unzip") {
+					spinner.Stop()
+					ui.Message.Errorf("unzip not found — install: brew install unzip")
+
+					continue
+				}
+
+				output, err = exec.CommandContext(context.Background(), "unzip", "-l", file).
+					Output()
+			case "tar":
+				output, err = exec.CommandContext(context.Background(), "tar", "tf", file).Output()
+			case "gz", "tgz":
+				output, err = exec.CommandContext(context.Background(), "tar", "tzf", file).Output()
+			case "zst", "zstd":
+				if util.HasTool("zstd") {
+					output, err = exec.CommandContext(context.Background(), "zstd", "-dc", file).
+						Output()
+				} else {
+					spinner.Stop()
+					ui.Message.Errorf("zstd not found — install: brew install zstd")
+
+					continue
+				}
+			case "xz", "txz":
+				output, err = exec.CommandContext(context.Background(), "xz", "-dc", file).Output()
+			case "bz2", "tbz2":
+				output, err = exec.CommandContext(context.Background(), "bzip2", "-dc", file).
+					Output()
+			default:
+				spinner.Stop()
+				ui.Message.Errorf("Unsupported archive: .%s", ext)
+
+				continue
+			}
 		}
 
 		spinner.Stop()
@@ -196,16 +292,4 @@ func List(opts ListOptions) error {
 	}
 
 	return nil
-}
-
-func fileExists(path string) bool {
-	_, err := os.Stat(path)
-
-	return err == nil
-}
-
-func hasTool(name string) bool {
-	_, err := exec.LookPath(name)
-
-	return err == nil
 }

--- a/internal/compress/archive.go
+++ b/internal/compress/archive.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
 	"github.com/y3owk1n/uts/internal/ui"
@@ -60,8 +61,9 @@ func deriveArchiveName(files []string) string {
 		}
 
 		base := filepath.Base(files[0])
+		name := strings.TrimSuffix(base, filepath.Ext(base))
 
-		return stringsTrimSuffix(base, filepath.Ext(base))
+		return strings.TrimSuffix(name, ".tar")
 	}
 
 	parent := filepath.Dir(files[0])
@@ -147,7 +149,7 @@ func archiveWith(algo, outDir, name string, files []string) string {
 			append([]string{"-czf", output}, files...)...,
 		)
 	case "zstd", "zst":
-		if !hasTool("zstd") {
+		if !util.HasTool("zstd") {
 			return ""
 		}
 
@@ -163,7 +165,7 @@ func archiveWith(algo, outDir, name string, files []string) string {
 			append([]string{"-cJf", output}, files...)...,
 		)
 	case "brotli", "br":
-		if !hasTool("brotli") {
+		if !util.HasTool("brotli") {
 			return ""
 		}
 
@@ -202,7 +204,7 @@ func archiveWith(algo, outDir, name string, files []string) string {
 
 		return output
 	case "zip":
-		if !hasTool("zip") {
+		if !util.HasTool("zip") {
 			return ""
 		}
 
@@ -231,12 +233,4 @@ func archiveWith(algo, outDir, name string, files []string) string {
 	}
 
 	return output
-}
-
-func stringsTrimSuffix(str, suffix string) string {
-	if len(str) >= len(suffix) && str[len(str)-len(suffix):] == suffix {
-		return str[:len(str)-len(suffix)]
-	}
-
-	return str
 }

--- a/internal/compress/audio.go
+++ b/internal/compress/audio.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/util"
 )
@@ -25,6 +26,13 @@ func Audio(opts AudioOptions) error {
 		return err
 	}
 
+	if !util.HasTool("ffmpeg") {
+		return derrors.New(
+			derrors.CodeToolNotFound,
+			"ffmpeg not found — install: brew install ffmpeg",
+		)
+	}
+
 	ui.Message.Infof(
 		"Audio compression at %s quality (bitrate=%s, codec=aac)",
 		opts.Quality,
@@ -39,7 +47,7 @@ func Audio(opts AudioOptions) error {
 			continue
 		}
 
-		out := util.OutputPathExt(file, "small", "m4a")
+		out := util.CalcOutputPath(file, "small", opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
@@ -90,7 +98,7 @@ func Audio(opts AudioOptions) error {
 			)
 
 			if opts.InPlace {
-				util.MaybeInPlace(out, file)
+				util.MaybeReplaceOrRemove(out, file)
 			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -44,7 +44,7 @@ func Image(opts ImageOptions) error {
 		}
 
 		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(file), "."))
-		out := util.OutputPath(file, "small")
+		out := util.CalcOutputPath(file, "small", opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
@@ -112,7 +112,7 @@ func Image(opts ImageOptions) error {
 			)
 
 			if opts.InPlace {
-				util.MaybeInPlace(out, file)
+				util.MaybeReplaceOrRemove(out, file)
 			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)
@@ -127,7 +127,7 @@ func Image(opts ImageOptions) error {
 }
 
 func compressPNG(file, out string, quality int) error {
-	if hasTool("pngquant") {
+	if util.HasTool("pngquant") {
 		ui.Message.Mutedf("Using pngquant")
 
 		cmd := exec.CommandContext(context.Background(), "pngquant",
@@ -139,7 +139,7 @@ func compressPNG(file, out string, quality int) error {
 			return err
 		}
 
-		if hasTool("optipng") && util.FileExists(out) {
+		if util.HasTool("optipng") && util.FileExists(out) {
 			ui.Message.Mutedf("Optimizing with optipng")
 
 			_ = exec.CommandContext(context.Background(), "optipng", "-quiet", "-o2", out).Run()
@@ -148,7 +148,7 @@ func compressPNG(file, out string, quality int) error {
 		return nil
 	}
 
-	if hasTool("optipng") {
+	if util.HasTool("optipng") {
 		ui.Message.Mutedf("Using optipng")
 
 		err := copyFile(file, out)
@@ -163,7 +163,7 @@ func compressPNG(file, out string, quality int) error {
 }
 
 func compressJPEG(file, out string, quality int) error {
-	if hasTool("jpegoptim") {
+	if util.HasTool("jpegoptim") {
 		ui.Message.Mutedf("Using jpegoptim")
 
 		err := copyFile(file, out)
@@ -179,7 +179,7 @@ func compressJPEG(file, out string, quality int) error {
 }
 
 func compressWebP(file, out string, quality int) error {
-	if hasTool("cwebp") {
+	if util.HasTool("cwebp") {
 		ui.Message.Mutedf("Using cwebp")
 
 		return exec.CommandContext(context.Background(), "cwebp", "-q", strconv.Itoa(quality), "-m", "6", file, "-o", out).
@@ -190,7 +190,7 @@ func compressWebP(file, out string, quality int) error {
 }
 
 func compressGIF(file, out string) error {
-	if hasTool("gifsicle") {
+	if util.HasTool("gifsicle") {
 		ui.Message.Mutedf("Using gifsicle")
 
 		return exec.CommandContext(context.Background(), "gifsicle", "-O3", "--lossy=80", file, "-o", out).
@@ -205,7 +205,7 @@ func compressGeneric(file, out string, quality int) error {
 }
 
 func compressHEIC(file, out string, quality int) error {
-	if hasTool("heif-convert") {
+	if util.HasTool("heif-convert") {
 		ui.Message.Mutedf("Using heif-convert")
 
 		return exec.CommandContext(context.Background(), "heif-convert", "-q", strconv.Itoa(quality), file, out).
@@ -216,14 +216,14 @@ func compressHEIC(file, out string, quality int) error {
 }
 
 func compressAVIF(file, out string, quality int) error {
-	if hasTool("cavif") {
+	if util.HasTool("cavif") {
 		ui.Message.Mutedf("Using cavif")
 
 		return exec.CommandContext(context.Background(), "cavif", "-q", strconv.Itoa(quality), "-s", "6", "-o", out, file).
 			Run()
 	}
 
-	if hasTool("avifenc") {
+	if util.HasTool("avifenc") {
 		ui.Message.Mutedf("Using avifenc")
 
 		quantizer := (100 - quality) * 63 / 100
@@ -236,14 +236,14 @@ func compressAVIF(file, out string, quality int) error {
 }
 
 func magickCmd(input, output string, quality int) error {
-	if hasTool("magick") {
+	if util.HasTool("magick") {
 		ui.Message.Mutedf("Using ImageMagick")
 
 		return exec.CommandContext(context.Background(), "magick", input, "-quality", strconv.Itoa(quality), "-strip", output).
 			Run()
 	}
 
-	if hasTool("convert") {
+	if util.HasTool("convert") {
 		ui.Message.Mutedf("Using ImageMagick (convert)")
 
 		return exec.CommandContext(context.Background(), "convert", input, "-quality", strconv.Itoa(quality), "-strip", output).
@@ -262,10 +262,4 @@ func copyFile(src, dst string) error {
 	}
 
 	return os.WriteFile(dst, input, 0o644)
-}
-
-func hasTool(name string) bool {
-	_, err := exec.LookPath(name)
-
-	return err == nil
 }

--- a/internal/compress/pdf.go
+++ b/internal/compress/pdf.go
@@ -44,7 +44,7 @@ func PDF(opts PDFOptions) error {
 			continue
 		}
 
-		out := util.OutputPath(file, "small")
+		out := util.CalcOutputPath(file, "small", opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
@@ -100,6 +100,10 @@ func PDF(opts PDFOptions) error {
 				util.HumanSize(newSize),
 				ratio,
 			)
+
+			if opts.InPlace {
+				util.MaybeInPlace(out, file)
+			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)
 			ui.Message.Mutedf("gs: %s", string(output))

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"strconv"
 
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/util"
 )
@@ -26,6 +27,13 @@ func Video(opts VideoOptions) error {
 		return err
 	}
 
+	if !util.HasTool("ffmpeg") {
+		return derrors.New(
+			derrors.CodeToolNotFound,
+			"ffmpeg not found — install: brew install ffmpeg",
+		)
+	}
+
 	ui.Message.Infof(
 		"Video compression at %s quality (crf=%d, preset=%s)",
 		opts.Quality,
@@ -41,7 +49,7 @@ func Video(opts VideoOptions) error {
 			continue
 		}
 
-		out := util.OutputPath(file, "small")
+		out := util.CalcOutputPath(file, "small", opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
@@ -97,7 +105,7 @@ func Video(opts VideoOptions) error {
 			)
 
 			if opts.InPlace {
-				util.MaybeInPlace(out, file)
+				util.MaybeReplaceOrRemove(out, file)
 			}
 		} else {
 			ui.Message.Errorf("Compression failed: %s", file)

--- a/internal/convert/audio.go
+++ b/internal/convert/audio.go
@@ -53,7 +53,7 @@ func Audio(opts AudioOptions) error {
 			continue
 		}
 
-		out := util.ConvertOutputPath(file, extHint)
+		out := util.CalcConvertOutputPath(file, extHint, opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf(
@@ -101,7 +101,7 @@ func Audio(opts AudioOptions) error {
 			)
 
 			if opts.InPlace {
-				util.RemoveInPlace(file)
+				util.MaybeReplaceOrRemove(out, file)
 			}
 		} else {
 			ui.Message.Errorf("Conversion failed: %s", file)

--- a/internal/convert/image.go
+++ b/internal/convert/image.go
@@ -60,7 +60,7 @@ func Image(opts ImageOptions) error {
 			continue
 		}
 
-		out := util.ConvertOutputPath(file, target)
+		out := util.CalcConvertOutputPath(file, target, opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf(
@@ -92,14 +92,14 @@ func Image(opts ImageOptions) error {
 		var convertErr error
 		switch {
 		case hasMagick():
-			if hasTool("magick") {
+			if util.HasTool("magick") {
 				convertErr = exec.CommandContext(context.Background(), "magick", file, "-quality", strconv.Itoa(qualityVal), "-strip", out).
 					Run()
 			} else {
 				convertErr = exec.CommandContext(context.Background(), "convert", file, "-quality", strconv.Itoa(qualityVal), "-strip", out).
 					Run()
 			}
-		case hasTool("sips"):
+		case util.HasTool("sips"):
 			sipsFmt := target
 			if target == "jpg" {
 				sipsFmt = "jpeg"
@@ -125,7 +125,7 @@ func Image(opts ImageOptions) error {
 			)
 
 			if opts.InPlace {
-				util.RemoveInPlace(file)
+				util.MaybeReplaceOrRemove(out, file)
 			}
 		} else {
 			ui.Message.Errorf("Conversion failed: %s", file)
@@ -140,11 +140,5 @@ func Image(opts ImageOptions) error {
 }
 
 func hasMagick() bool {
-	return hasTool("magick") || hasTool("convert")
-}
-
-func hasTool(name string) bool {
-	_, err := exec.LookPath(name)
-
-	return err == nil
+	return util.HasTool("magick") || util.HasTool("convert")
 }

--- a/internal/convert/pdf.go
+++ b/internal/convert/pdf.go
@@ -94,7 +94,7 @@ func pdfToImages(opts PDFOptions) error {
 
 		var convertErr error
 		switch {
-		case hasTool("pdftoppm"):
+		case util.HasTool("pdftoppm"):
 			imgExt := target
 			if target == "jpg" {
 				imgExt = "jpeg"
@@ -104,7 +104,7 @@ func pdfToImages(opts PDFOptions) error {
 				Run()
 		case hasMagick():
 			magick := "magick"
-			if !hasTool("magick") {
+			if !util.HasTool("magick") {
 				magick = "convert"
 			}
 
@@ -189,7 +189,7 @@ func imagesToPDF(opts PDFOptions) error {
 	var convertErr error
 	if hasMagick() {
 		magick := "magick"
-		if !hasTool("magick") {
+		if !util.HasTool("magick") {
 			magick = "convert"
 		}
 

--- a/internal/convert/video.go
+++ b/internal/convert/video.go
@@ -48,7 +48,7 @@ func Video(opts VideoOptions) error {
 			continue
 		}
 
-		out := util.ConvertOutputPath(file, target)
+		out := util.CalcConvertOutputPath(file, target, opts.OutputDir)
 		origSize := util.FileSize(file)
 
 		ui.Message.Stepf(
@@ -96,7 +96,7 @@ func Video(opts VideoOptions) error {
 			)
 
 			if opts.InPlace {
-				util.RemoveInPlace(file)
+				util.MaybeReplaceOrRemove(out, file)
 			}
 		} else {
 			ui.Message.Errorf("Conversion failed: %s", file)

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -3,7 +3,9 @@ package util
 
 import (
 	"fmt"
+	"io/fs"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -125,10 +127,20 @@ func FileExists(path string) bool {
 }
 
 // ResolveGlobs resolves glob patterns and returns matching file paths.
+// When recursive is true, patterns containing "**" are expanded recursively.
 func ResolveGlobs(args []string, recursive bool) []string {
 	var result []string
 	for _, arg := range args {
 		if strings.ContainsAny(arg, "*?[") {
+			if recursive && strings.Contains(arg, "**") {
+				matches := resolveRecursiveGlob(arg)
+				if len(matches) > 0 {
+					result = append(result, matches...)
+				}
+
+				continue
+			}
+
 			matches, err := filepath.Glob(arg)
 			if err != nil || len(matches) == 0 {
 				continue
@@ -141,6 +153,49 @@ func ResolveGlobs(args []string, recursive bool) []string {
 	}
 
 	return result
+}
+
+// resolveRecursiveGlob handles "**" glob patterns by walking the directory tree.
+func resolveRecursiveGlob(pattern string) []string {
+	parts := strings.SplitN(pattern, "**", 2)
+	if len(parts) != 2 {
+		return nil
+	}
+
+	root := parts[0]
+	suffix := parts[1]
+
+	// Clean leading separator from suffix so it matches like "/*.png".
+	suffix = strings.TrimPrefix(suffix, "/")
+
+	if root == "" {
+		root = "."
+	}
+
+	var matches []string
+
+	//nolint:nilerr // Walk errors are non-fatal; empty result is fine for globs.
+	err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if d.IsDir() {
+			return nil
+		}
+
+		match, _ := filepath.Match(suffix, filepath.Base(path))
+		if match {
+			matches = append(matches, path)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return nil
+	}
+
+	return matches
 }
 
 // EnsureDir ensures the parent directory of the given path exists.
@@ -161,4 +216,44 @@ func InPlaceHint(inPlace bool) string {
 	}
 
 	return ""
+}
+
+// HasTool reports whether the named executable is in PATH.
+func HasTool(name string) bool {
+	_, err := exec.LookPath(name)
+
+	return err == nil
+}
+
+// CalcOutputPath computes an output path respecting the output directory.
+// When outputDir is non-empty the file is placed there; otherwise it stays
+// next to the input with the given suffix inserted before the extension.
+func CalcOutputPath(input, suffix, outputDir string) string {
+	if outputDir != "" {
+		return filepath.Join(outputDir, filepath.Base(input))
+	}
+
+	return OutputPath(input, suffix)
+}
+
+// CalcConvertOutputPath computes a conversion output path respecting the
+// output directory. When outputDir is non-empty the file is placed there;
+// otherwise it stays next to the input with the new extension.
+func CalcConvertOutputPath(input, targetExt, outputDir string) string {
+	if outputDir != "" {
+		return filepath.Join(outputDir, filepath.Base(input))
+	}
+
+	return ConvertOutputPath(input, targetExt)
+}
+
+// MaybeReplaceOrRemove handles in-place replacement after processing.
+// If compressed has the same extension as original it is renamed in place;
+// otherwise the original is deleted (used for conversions to different formats).
+func MaybeReplaceOrRemove(compressed, original string) {
+	if filepath.Ext(compressed) == filepath.Ext(original) {
+		MaybeInPlace(compressed, original)
+	} else {
+		RemoveInPlace(original)
+	}
 }


### PR DESCRIPTION
## Summary

This PR fixes several bugs and improves code quality across the compress, convert, and archive packages.

### Bug Fixes
- **Fix `--output` flag being ignored** in all compress/convert functions — files now correctly respect the `-o` output directory
- **Add missing `--in-place` support for PDF compression** — `uts pdf compress file.pdf -i` now works as expected
- **Fix HEIC/AVIF in-place mode** — was incorrectly overwriting the original file with a different extension; now correctly deletes the original when the output has a different format
- **Fix archive extract/list for double extensions** (`.tar.zst`, `.tar.bz2`, `.tar.xz`) — `filepath.Ext` only returns the last extension, so compound extensions were not handled
- **Fix `resolveGlobs` ignoring `recursive` parameter** — `**` patterns now work via `filepath.WalkDir`
- **Fix `deriveArchiveName` producing wrong names** for `.tar.gz` files (e.g., `archive.tar.gz.tar.gz` → `archive.tar.gz`)

### Code Quality
- **Consolidate duplicated `hasTool`/`fileExists`** into `util.HasTool`/`util.FileExists`
- **Remove reimplemented `strings.TrimSuffix`** in archive package, use standard library
- **Add upfront `ffmpeg` availability checks** in video/audio compress — clear error messages instead of cryptic exec failures
- **Add `MaybeReplaceOrRemove` helper** for correct in-place operations (same extension → rename, different extension → delete original)
- **Add `CalcOutputPath`/`CalcConvertOutputPath`** helpers that respect the `OutputDir` parameter