### PR TITLE
refactor(internal): add format, ffmpeg and job packages

### DIFF
--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -1,0 +1,211 @@
+// Package ffmpeg builds ffmpeg argument lists and reads ffprobe metadata so
+// the video, audio and info commands agree on codecs and flags.
+//
+//nolint:goconst,tagliatelle // ffprobe dictates snake_case JSON keys.
+package ffmpeg
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/util"
+)
+
+// ErrNoProbe is returned when ffprobe is not installed.
+var ErrNoProbe = errors.New("ffprobe not found")
+
+// Check returns an error when ffmpeg is not installed.
+func Check() error {
+	if util.HasTool("ffmpeg") {
+		return nil
+	}
+
+	return derrors.New(derrors.CodeToolNotFound, "ffmpeg not found — install: brew install ffmpeg")
+}
+
+// EncodeArgs returns ffmpeg arguments that re-encode in into out for the given
+// container at a CRF quality. Codec-specific flags are chosen so every
+// supported container produces a playable file:
+//
+//   - x264/x265 get -preset, yuv420p for player compatibility, and hvc1
+//     tagging so Apple players recognize HEVC in mp4/mov
+//   - VP9 needs -b:v 0 for CRF to mean constant quality, and speed is set via
+//     -cpu-used because it has no -preset
+//   - mp4/mov get +faststart so playback can begin before download ends
+func EncodeArgs(input, out, container string, crf int, preset string) []string {
+	container = format.Normalize(strings.TrimPrefix(container, "."))
+	vcodec, acodec := format.VideoCodecs(container)
+
+	args := []string{
+		"-i",
+		input,
+		"-map",
+		"0:v:0",
+		"-map",
+		"0:a?",
+		"-c:v",
+		vcodec,
+		"-crf",
+		strconv.Itoa(crf),
+	}
+
+	switch vcodec {
+	case "libvpx-vp9":
+		args = append(args, "-b:v", "0", "-row-mt", "1", "-cpu-used", vp9Speed(preset))
+	default:
+		args = append(args, "-preset", preset, "-pix_fmt", "yuv420p")
+
+		if vcodec == "libx265" && (container == "mp4" || container == "mov") {
+			args = append(args, "-tag:v", "hvc1")
+		}
+	}
+
+	args = append(args, "-c:a", acodec, "-b:a", "128k")
+
+	if container == "mp4" || container == "mov" || container == "m4v" {
+		args = append(args, "-movflags", "+faststart")
+	}
+
+	return append(args, "-y", out)
+}
+
+func vp9Speed(preset string) string {
+	switch preset {
+	case "slow":
+		return "1"
+	case "fast":
+		return "4"
+	}
+
+	return "2"
+}
+
+// RemuxArgs returns ffmpeg arguments that copy every video and audio stream
+// into a new container without re-encoding. Subtitle and data streams are
+// dropped because their support varies per container.
+func RemuxArgs(input, out, container string) []string {
+	args := []string{"-i", input, "-map", "0:v", "-map", "0:a?", "-c", "copy"}
+
+	switch format.Normalize(strings.TrimPrefix(container, ".")) {
+	case "mp4", "mov", "m4v":
+		args = append(args, "-movflags", "+faststart")
+	}
+
+	return append(args, "-y", out)
+}
+
+// Stream is one ffprobe stream.
+type Stream struct {
+	Type       string `json:"codec_type"`
+	Codec      string `json:"codec_name"`
+	Width      int    `json:"width"`
+	Height     int    `json:"height"`
+	SampleRate string `json:"sample_rate"`
+	Channels   int    `json:"channels"`
+	FrameRate  string `json:"r_frame_rate"`
+}
+
+// Info is the subset of ffprobe output uts cares about.
+type Info struct {
+	Streams []Stream `json:"streams"`
+	Format  struct {
+		Duration string `json:"duration"`
+		BitRate  string `json:"bit_rate"`
+		Name     string `json:"format_name"`
+	} `json:"format"`
+}
+
+// Video returns the first video stream, or nil.
+func (i Info) Video() *Stream {
+	for idx := range i.Streams {
+		if i.Streams[idx].Type == "video" {
+			return &i.Streams[idx]
+		}
+	}
+
+	return nil
+}
+
+// Audio returns the first audio stream, or nil.
+func (i Info) Audio() *Stream {
+	for idx := range i.Streams {
+		if i.Streams[idx].Type == "audio" {
+			return &i.Streams[idx]
+		}
+	}
+
+	return nil
+}
+
+// Duration returns the container duration in seconds, or 0 when unknown.
+func (i Info) Duration() float64 {
+	dur, err := strconv.ParseFloat(i.Format.Duration, 64)
+	if err != nil {
+		return 0
+	}
+
+	return dur
+}
+
+// BitRate returns the overall bit rate in bits per second, or 0 when unknown.
+func (i Info) BitRate() int64 {
+	rate, err := strconv.ParseInt(i.Format.BitRate, 10, 64)
+	if err != nil {
+		return 0
+	}
+
+	return rate
+}
+
+// Probe reads stream and container metadata with ffprobe.
+func Probe(file string) (*Info, error) {
+	if !util.HasTool("ffprobe") {
+		return nil, ErrNoProbe
+	}
+
+	out, err := exec.CommandContext(context.Background(), "ffprobe",
+		"-v", "error", "-show_streams", "-show_format", "-of", "json", file).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var info Info
+
+	err = json.Unmarshal(out, &info)
+	if err != nil {
+		return nil, err
+	}
+
+	return &info, nil
+}
+
+// CanRemux reports whether every video and audio stream of a probed file can
+// be copied as-is into the target container.
+func CanRemux(info *Info, container string) bool {
+	seen := false
+
+	for _, stream := range info.Streams {
+		if stream.Type != "video" && stream.Type != "audio" {
+			continue
+		}
+
+		// Embedded cover art is a still image, not a video track.
+		if stream.Type == "video" && (stream.Codec == "mjpeg" || stream.Codec == "png") {
+			return false
+		}
+
+		if !format.ContainerAccepts(container, stream.Codec) {
+			return false
+		}
+
+		seen = true
+	}
+
+	return seen
+}

--- a/internal/ffmpeg/ffmpeg_test.go
+++ b/internal/ffmpeg/ffmpeg_test.go
@@ -1,0 +1,97 @@
+//nolint:goconst
+package ffmpeg_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/y3owk1n/uts/internal/ffmpeg"
+)
+
+func has(args []string, want ...string) bool {
+	joined := " " + strings.Join(args, " ") + " "
+
+	return strings.Contains(joined, " "+strings.Join(want, " ")+" ")
+}
+
+func TestEncodeArgsVP9(t *testing.T) {
+	args := ffmpeg.EncodeArgs("in.mp4", "out.webm", "webm", 30, "fast")
+
+	if !has(args, "-c:v", "libvpx-vp9") || !has(args, "-b:v", "0") || !has(args, "-cpu-used", "4") {
+		t.Errorf("VP9 args missing constant-quality flags: %v", args)
+	}
+
+	if slices.Contains(args, "-preset") || slices.Contains(args, "-movflags") {
+		t.Errorf("VP9 args must not carry x264-only flags: %v", args)
+	}
+}
+
+func TestEncodeArgsMP4(t *testing.T) {
+	args := ffmpeg.EncodeArgs("in.mov", "out.mp4", ".mp4", 23, "slow")
+
+	for _, want := range [][]string{
+		{"-c:v", "libx264"},
+		{"-crf", "23"},
+		{"-preset", "slow"},
+		{"-pix_fmt", "yuv420p"},
+		{"-movflags", "+faststart"},
+		{"-c:a", "aac"},
+	} {
+		if !has(args, want...) {
+			t.Errorf("mp4 args missing %v: %v", want, args)
+		}
+	}
+
+	if args[len(args)-1] != "out.mp4" {
+		t.Errorf("output must be last: %v", args)
+	}
+}
+
+func TestEncodeArgsHEVCTag(t *testing.T) {
+	if !has(ffmpeg.EncodeArgs("a", "b", "mkv", 28, "medium"), "-c:v", "libx265") {
+		t.Error("mkv should use libx265")
+	}
+
+	if has(ffmpeg.EncodeArgs("a", "b", "mkv", 28, "medium"), "-tag:v", "hvc1") {
+		t.Error("hvc1 tag only applies to mp4/mov")
+	}
+}
+
+func TestRemuxArgs(t *testing.T) {
+	args := ffmpeg.RemuxArgs("in.mov", "out.mp4", "mp4")
+	if !has(args, "-c", "copy") || !has(args, "-movflags", "+faststart") {
+		t.Errorf("remux args wrong: %v", args)
+	}
+
+	if has(ffmpeg.RemuxArgs("in.mp4", "out.mkv", "mkv"), "-movflags", "+faststart") {
+		t.Error("faststart is mp4/mov only")
+	}
+}
+
+func TestCanRemux(t *testing.T) {
+	info := &ffmpeg.Info{Streams: []ffmpeg.Stream{
+		{Type: "video", Codec: "h264"},
+		{Type: "audio", Codec: "aac"},
+		{Type: "data", Codec: "tmcd"},
+	}}
+
+	if !ffmpeg.CanRemux(info, "mp4") {
+		t.Error("h264+aac should remux into mp4")
+	}
+
+	if ffmpeg.CanRemux(info, "webm") {
+		t.Error("h264 must not remux into webm")
+	}
+
+	cover := &ffmpeg.Info{
+		Streams: []ffmpeg.Stream{{Type: "video", Codec: "mjpeg"}, {Type: "audio", Codec: "aac"}},
+	}
+	if ffmpeg.CanRemux(cover, "mp4") {
+		t.Error("cover art streams must force a re-encode")
+	}
+
+	if ffmpeg.CanRemux(&ffmpeg.Info{}, "mp4") {
+		t.Error("no streams means nothing to remux")
+	}
+}

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -1,0 +1,225 @@
+// Package format is the single source of truth for the file formats uts
+// understands: which extensions belong to which category and which codecs
+// each container expects.
+//
+//nolint:goconst
+package format
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+// Category is a media category handled by a uts command group.
+type Category string
+
+// Categories.
+const (
+	Image   Category = "image"
+	Video   Category = "video"
+	Audio   Category = "audio"
+	PDF     Category = "pdf"
+	Archive Category = "archive"
+	Unknown Category = "unknown"
+)
+
+// Extension sets per category, lowercase without the leading dot.
+var (
+	ImageExts = []string{
+		"png",
+		"jpg",
+		"jpeg",
+		"webp",
+		"gif",
+		"bmp",
+		"tiff",
+		"tif",
+		"heic",
+		"heif",
+		"avif",
+		"avifs",
+	}
+	VideoExts   = []string{"mp4", "mov", "mkv", "avi", "webm", "m4v", "flv", "wmv"}
+	AudioExts   = []string{"wav", "flac", "aac", "mp3", "m4a", "opus", "ogg", "wma"}
+	PDFExts     = []string{"pdf"}
+	ArchiveExts = []string{
+		"zip",
+		"tar",
+		"gz",
+		"tgz",
+		"zst",
+		"zstd",
+		"xz",
+		"txz",
+		"bz2",
+		"tbz2",
+		"br",
+		"7z",
+	}
+
+	// ImageTargets, VideoTargets, AudioTargets and PDFTargets are the
+	// conversion targets accepted by each convert command.
+	ImageTargets = []string{"jpg", "jpeg", "png", "webp", "gif", "bmp", "tiff", "tif", "avif"}
+	VideoTargets = []string{"mp4", "mkv", "webm", "mov", "avi", "flv"}
+	AudioTargets = []string{"mp3", "aac", "m4a", "wav", "flac", "opus", "ogg"}
+	PDFTargets   = []string{"jpg", "jpeg", "png", "pdf"}
+)
+
+// Ext returns the lowercase extension of path without the leading dot.
+func Ext(path string) string {
+	return strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))
+}
+
+// Classify returns the category an extension belongs to.
+func Classify(ext string) Category {
+	ext = strings.ToLower(strings.TrimPrefix(ext, "."))
+
+	switch {
+	case slices.Contains(ImageExts, ext):
+		return Image
+	case slices.Contains(VideoExts, ext):
+		return Video
+	case slices.Contains(AudioExts, ext):
+		return Audio
+	case slices.Contains(PDFExts, ext):
+		return PDF
+	case slices.Contains(ArchiveExts, ext):
+		return Archive
+	}
+
+	return Unknown
+}
+
+// Exts returns the input extensions a category accepts.
+func Exts(cat Category) []string {
+	switch cat {
+	case Image:
+		return ImageExts
+	case Video:
+		return VideoExts
+	case Audio:
+		return AudioExts
+	case PDF:
+		return PDFExts
+	case Archive:
+		return ArchiveExts
+	case Unknown:
+		return nil
+	}
+
+	return nil
+}
+
+// Normalize maps alias extensions to their canonical form (jpeg -> jpg, tif -> tiff).
+func Normalize(ext string) string {
+	switch strings.ToLower(ext) {
+	case "jpeg":
+		return "jpg"
+	case "tif":
+		return "tiff"
+	case "heif":
+		return "heic"
+	case "zstd":
+		return "zst"
+	}
+
+	return strings.ToLower(ext)
+}
+
+// Same reports whether two extensions denote the same format.
+func Same(a, b string) bool {
+	return Normalize(a) == Normalize(b)
+}
+
+// VideoCodecs returns the encoder pair (video, audio) uts uses for a container.
+func VideoCodecs(ext string) (string, string) {
+	switch Normalize(strings.TrimPrefix(ext, ".")) {
+	case "mkv":
+		return "libx265", "aac"
+	case "webm":
+		return "libvpx-vp9", "libopus"
+	case "avi":
+		return "libx264", "mp3"
+	}
+
+	return "libx264", "aac"
+}
+
+// ContainerAccepts reports whether a container can hold the given ffprobe
+// codec name without re-encoding. It is deliberately conservative: only
+// well-supported pairings return true so a stream copy never yields an
+// unplayable file.
+func ContainerAccepts(container, codec string) bool {
+	codec = strings.ToLower(codec)
+
+	switch Normalize(strings.TrimPrefix(container, ".")) {
+	case "mp4", "mov", "m4v":
+		return slices.Contains(
+			[]string{"h264", "hevc", "av1", "mpeg4", "aac", "mp3", "alac", "ac3"},
+			codec,
+		)
+	case "mkv":
+		return slices.Contains([]string{
+			"h264", "hevc", "av1", "vp8", "vp9", "mpeg4", "mpeg2video",
+			"aac", "mp3", "opus", "vorbis", "flac", "ac3", "eac3", "dts", "pcm_s16le",
+		}, codec)
+	case "webm":
+		return slices.Contains([]string{"vp8", "vp9", "av1", "opus", "vorbis"}, codec)
+	case "avi":
+		return slices.Contains([]string{"h264", "mpeg4", "mp3", "ac3", "pcm_s16le"}, codec)
+	case "flv":
+		return slices.Contains([]string{"h264", "aac", "mp3"}, codec)
+	}
+
+	return false
+}
+
+// AudioCodec returns the ffmpeg encoder and output extension for an audio
+// target. The second return is empty when the target is unsupported.
+func AudioCodec(target string) (string, string) {
+	switch strings.ToLower(target) {
+	case "mp3":
+		return "libmp3lame", "mp3"
+	case "aac", "m4a":
+		return "aac", "m4a"
+	case "wav":
+		return "pcm_s16le", "wav"
+	case "flac":
+		return "flac", "flac"
+	case "opus":
+		return "libopus", "opus"
+	case "ogg":
+		return "libvorbis", "ogg"
+	}
+
+	return "", ""
+}
+
+// Lossless reports whether an audio extension is a lossless format, where a
+// bitrate setting is meaningless.
+func Lossless(ext string) bool {
+	switch strings.ToLower(strings.TrimPrefix(ext, ".")) {
+	case "wav", "flac", "alac", "aiff", "aif":
+		return true
+	}
+
+	return false
+}
+
+// AudioCompressTarget picks the output extension and encoder used when
+// compressing an audio file. Lossy inputs keep their container so the result
+// is a smaller file of the same kind. Lossless and exotic inputs become AAC in
+// an .m4a container, the most widely playable lossy format.
+func AudioCompressTarget(ext string) (string, string) {
+	switch strings.ToLower(strings.TrimPrefix(ext, ".")) {
+	case "mp3":
+		return "libmp3lame", "mp3"
+	case "ogg":
+		return "libvorbis", "ogg"
+	case "opus":
+		return "libopus", "opus"
+	}
+
+	return "aac", "m4a"
+}

--- a/internal/format/format_test.go
+++ b/internal/format/format_test.go
@@ -1,0 +1,132 @@
+//nolint:goconst
+package format_test
+
+import (
+	"testing"
+
+	"github.com/y3owk1n/uts/internal/format"
+)
+
+func TestClassify(t *testing.T) {
+	tests := []struct {
+		ext  string
+		want format.Category
+	}{
+		{"png", format.Image},
+		{".JPG", format.Image},
+		{"mov", format.Video},
+		{"flac", format.Audio},
+		{"pdf", format.PDF},
+		{"tgz", format.Archive},
+		{"br", format.Archive},
+		{"txt", format.Unknown},
+		{"", format.Unknown},
+	}
+	for _, testCase := range tests {
+		if got := format.Classify(testCase.ext); got != testCase.want {
+			t.Errorf("Classify(%q) = %q; want %q", testCase.ext, got, testCase.want)
+		}
+	}
+}
+
+func TestExt(t *testing.T) {
+	tests := []struct{ path, want string }{
+		{"photo.HEIC", "heic"},
+		{"/a/b/clip.tar.gz", "gz"},
+		{"noext", ""},
+		{".hidden", "hidden"},
+	}
+	for _, testCase := range tests {
+		if got := format.Ext(testCase.path); got != testCase.want {
+			t.Errorf("Ext(%q) = %q; want %q", testCase.path, got, testCase.want)
+		}
+	}
+}
+
+func TestSame(t *testing.T) {
+	if !format.Same("jpeg", "jpg") || !format.Same("TIF", "tiff") || format.Same("png", "jpg") {
+		t.Error("Same: alias handling is wrong")
+	}
+}
+
+func TestAudioCompressTarget(t *testing.T) {
+	tests := []struct{ ext, codec, out string }{
+		{"mp3", "libmp3lame", "mp3"},
+		{"ogg", "libvorbis", "ogg"},
+		{"opus", "libopus", "opus"},
+		{"wav", "aac", "m4a"},
+		{"flac", "aac", "m4a"},
+		{"m4a", "aac", "m4a"},
+		{"wma", "aac", "m4a"},
+	}
+	for _, testCase := range tests {
+		codec, out := format.AudioCompressTarget(testCase.ext)
+		if codec != testCase.codec || out != testCase.out {
+			t.Errorf(
+				"AudioCompressTarget(%q) = (%q, %q); want (%q, %q)",
+				testCase.ext,
+				codec,
+				out,
+				testCase.codec,
+				testCase.out,
+			)
+		}
+	}
+}
+
+func TestContainerAccepts(t *testing.T) {
+	tests := []struct {
+		container, codec string
+		want             bool
+	}{
+		{"mp4", "h264", true},
+		{"mp4", "aac", true},
+		{"mp4", "vp9", false},
+		{"mp4", "pcm_s16le", false},
+		{"webm", "vp9", true},
+		{"webm", "h264", false},
+		{"mkv", "h264", true},
+		{"mkv", "opus", true},
+		{"flv", "hevc", false},
+		{"gif", "h264", false},
+	}
+	for _, testCase := range tests {
+		if got := format.ContainerAccepts(
+			testCase.container,
+			testCase.codec,
+		); got != testCase.want {
+			t.Errorf(
+				"ContainerAccepts(%q, %q) = %v; want %v",
+				testCase.container,
+				testCase.codec,
+				got,
+				testCase.want,
+			)
+		}
+	}
+}
+
+func TestVideoCodecs(t *testing.T) {
+	tests := []struct{ ext, v, a string }{
+		{".mp4", "libx264", "aac"},
+		{"mov", "libx264", "aac"},
+		{"mkv", "libx265", "aac"},
+		{"webm", "libvpx-vp9", "libopus"},
+		{"avi", "libx264", "mp3"},
+		{"flv", "libx264", "aac"},
+		{"unknown", "libx264", "aac"},
+	}
+	for _, testCase := range tests {
+		video, audio := format.VideoCodecs(testCase.ext)
+		if video != testCase.v || audio != testCase.a {
+			t.Errorf(
+				"VideoCodecs(%q) = (%q, %q); want (%q, %q)",
+				testCase.ext,
+				video,
+				audio,
+				testCase.v,
+				testCase.a,
+			)
+		}
+	}
+}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -1,0 +1,323 @@
+// Package job runs the per-file pipeline shared by every compress and convert
+// command: existence check, dry-run preview, spinner, external tool steps,
+// size report, in-place replacement and a final summary with exit status.
+package job
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"charm.land/log/v2"
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/ui"
+	"github.com/y3owk1n/uts/internal/util"
+)
+
+const tailLines = 12
+
+var errNoOutput = errors.New("no output produced")
+
+// Step is one unit of work for a file: either an external command or a Go
+// function with a human-readable description for dry runs.
+type Step struct {
+	Cmd  *exec.Cmd
+	Desc string
+	Fn   func() error
+}
+
+// Exec builds a command step.
+func Exec(name string, args ...string) Step {
+	return Step{Cmd: exec.CommandContext(context.Background(), name, args...)}
+}
+
+// Do builds a function step.
+func Do(desc string, fn func() error) Step {
+	return Step{Desc: desc, Fn: fn}
+}
+
+// Job describes how one input becomes one output.
+type Job struct {
+	Input  string
+	Output string
+	Steps  []Step
+	// Note is shown under the step line, e.g. the tool chosen for this file.
+	Note string
+	// Skip, when set, is the reason the file is left alone.
+	Skip string
+}
+
+// Options configures a Run.
+type Options struct {
+	// Verb is the present participle shown while working, e.g. "Compressing".
+	Verb string
+	// Done is the past tense used in the summary, e.g. "Compressed".
+	Done string
+	// Noun names the inputs in the summary, e.g. "image files".
+	Noun string
+	// Compare reports the size delta and refuses to replace an original with
+	// a larger result.
+	Compare bool
+	InPlace bool
+	DryRun  bool
+	// Code is the error code returned when any file fails.
+	Code derrors.Code
+}
+
+// Run plans and executes one job per file. It never stops at the first
+// failure; every file gets its turn and an error summarizing the failures is
+// returned at the end so the CLI exits non-zero.
+func Run(files []string, opts Options, plan func(file string) (*Job, error)) error {
+	total := len(files)
+
+	var done, failed, skipped int
+
+	var saved int64
+
+	for idx, file := range files {
+		if !util.FileExists(file) {
+			ui.Message.Warnf("File not found: %s", file)
+
+			failed++
+
+			continue
+		}
+
+		job, err := plan(file)
+		if err != nil {
+			ui.Message.Errorf("%s: %v", file, err)
+
+			failed++
+
+			continue
+		}
+
+		if job.Skip != "" {
+			ui.Message.Warnf("%s, skipping: %s", job.Skip, file)
+
+			skipped++
+
+			continue
+		}
+
+		origSize := util.FileSize(file)
+		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
+
+		if job.Note != "" {
+			ui.Message.Mutedf("  %s", job.Note)
+		}
+
+		if opts.DryRun {
+			preview(job, opts.InPlace)
+
+			done++
+
+			continue
+		}
+
+		err = execute(job, opts)
+		if err != nil {
+			ui.Message.Errorf("%s failed: %s", strings.TrimSuffix(opts.Verb, "ing")+"ion", file)
+			ui.Message.Mutedf("%s", err)
+
+			failed++
+
+			continue
+		}
+
+		newSize := util.FileSize(job.Output)
+
+		switch {
+		case opts.Compare:
+			ui.Message.Successf("%s: %s → %s %s", file, util.HumanSize(origSize),
+				util.HumanSize(newSize), util.CompressionRatio(origSize, newSize))
+
+			if newSize >= origSize {
+				ui.Message.Warnf("Result is not smaller than the original, keeping %s", file)
+
+				if opts.InPlace {
+					_ = os.Remove(job.Output)
+				}
+
+				skipped++
+
+				continue
+			}
+
+			saved += origSize - newSize
+		case isDir(job.Output):
+			ui.Message.Successf("%s → %s/", file, job.Output)
+		default:
+			ui.Message.Successf("%s → %s (%s)", file, job.Output, util.HumanSize(newSize))
+		}
+
+		if opts.InPlace {
+			replaceInPlace(job)
+		}
+
+		done++
+	}
+
+	if total > 1 {
+		summarize(opts, done, failed, skipped, saved)
+	}
+
+	if failed > 0 {
+		return derrors.Newf(opts.Code, "%d of %d files failed", failed, total)
+	}
+
+	return nil
+}
+
+func preview(job *Job, inPlace bool) {
+	ui.Message.Infof("[dry-run] Would write %s%s", job.Output, util.InPlaceHint(inPlace))
+
+	for _, step := range job.Steps {
+		if step.Cmd != nil {
+			ui.Message.Mutedf("  $ %s", util.Describe(step.Cmd))
+		} else {
+			ui.Message.Mutedf("  %s", step.Desc)
+		}
+	}
+}
+
+func execute(job *Job, opts Options) error {
+	err := util.EnsureDir(job.Output)
+	if err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+
+	existed := util.FileExists(job.Output)
+
+	spinner := ui.NewSpinner(nil, 0)
+	spinner.SetSuffix(fmt.Sprintf("%s %s...", opts.Verb, job.Input))
+	spinner.Start()
+
+	defer spinner.Stop()
+
+	for _, step := range job.Steps {
+		err := runStep(step)
+		if err != nil {
+			if !existed {
+				removeFile(job.Output)
+			}
+
+			return err
+		}
+	}
+
+	if !util.FileExists(job.Output) {
+		return fmt.Errorf("%w at %s", errNoOutput, job.Output)
+	}
+
+	return nil
+}
+
+func runStep(step Step) error {
+	if step.Cmd == nil {
+		log.Debug("step", "desc", step.Desc)
+
+		return step.Fn()
+	}
+
+	log.Debug("exec", "cmd", util.Describe(step.Cmd))
+
+	out, err := step.Cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w\n%s", step.Cmd.Args[0], err, tail(out))
+	}
+
+	return nil
+}
+
+// tail keeps the last lines of tool output and drops carriage-return progress
+// updates so a failed ffmpeg run prints a few useful lines, not a screenful.
+func tail(out []byte) string {
+	var lines []string
+
+	for line := range strings.SplitSeq(strings.TrimSpace(string(out)), "\n") {
+		if idx := strings.LastIndex(line, "\r"); idx >= 0 {
+			line = line[idx+1:]
+		}
+
+		if line = strings.TrimSpace(line); line != "" {
+			lines = append(lines, line)
+		}
+	}
+
+	if len(lines) > tailLines {
+		lines = lines[len(lines)-tailLines:]
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+
+	return err == nil && info.IsDir()
+}
+
+func removeFile(path string) {
+	info, err := os.Stat(path)
+	if err != nil || info.IsDir() {
+		return
+	}
+
+	_ = os.Remove(path)
+}
+
+// replaceInPlace makes the output take the original's place. Same-format
+// results overwrite the original; format-changing results delete the original
+// and take its base name.
+func replaceInPlace(job *Job) {
+	if format.Same(format.Ext(job.Output), format.Ext(job.Input)) {
+		util.MaybeInPlace(job.Output, job.Input)
+
+		return
+	}
+
+	util.RemoveInPlace(job.Input)
+
+	target := util.ConvertOutputPath(job.Input, format.Ext(job.Output))
+	if target != job.Output {
+		_ = os.Rename(job.Output, target)
+	}
+}
+
+func summarize(opts Options, done, failed, skipped int, saved int64) {
+	if opts.DryRun {
+		ui.Message.Infof("[dry-run] %d %s previewed, nothing written", done, opts.Noun)
+
+		return
+	}
+
+	msg := fmt.Sprintf("%s %d %s", opts.Done, done, opts.Noun)
+
+	var extra []string
+	if skipped > 0 {
+		extra = append(extra, fmt.Sprintf("%d skipped", skipped))
+	}
+
+	if failed > 0 {
+		extra = append(extra, fmt.Sprintf("%d failed", failed))
+	}
+
+	if len(extra) > 0 {
+		msg += " (" + strings.Join(extra, ", ") + ")"
+	}
+
+	if opts.Compare && saved > 0 {
+		msg += ", saved " + util.HumanSize(saved)
+	}
+
+	if failed > 0 {
+		ui.Message.Warnf("%s", msg)
+	} else {
+		ui.Message.Successf("%s", msg)
+	}
+}

--- a/internal/util/file.go
+++ b/internal/util/file.go
@@ -3,10 +3,12 @@ package util
 
 import (
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -226,8 +228,9 @@ func HasTool(name string) bool {
 }
 
 // CalcOutputPath computes an output path respecting the output directory.
-// When outputDir is non-empty the file is placed there; otherwise it stays
-// next to the input with the given suffix inserted before the extension.
+// When outputDir is non-empty the file is placed there under its own name;
+// otherwise it stays next to the input with the suffix inserted before the
+// extension.
 func CalcOutputPath(input, suffix, outputDir string) string {
 	if outputDir != "" {
 		return filepath.Join(outputDir, filepath.Base(input))
@@ -236,12 +239,21 @@ func CalcOutputPath(input, suffix, outputDir string) string {
 	return OutputPath(input, suffix)
 }
 
+// CalcOutputPathExt is CalcOutputPath for operations that change the
+// extension while keeping the "-suffix" naming (e.g. audio compress to .m4a).
+func CalcOutputPathExt(input, suffix, newExt, outputDir string) string {
+	if outputDir != "" {
+		return filepath.Join(outputDir, ConvertOutputPath(filepath.Base(input), newExt))
+	}
+
+	return OutputPathExt(input, suffix, newExt)
+}
+
 // CalcConvertOutputPath computes a conversion output path respecting the
-// output directory. When outputDir is non-empty the file is placed there;
-// otherwise it stays next to the input with the new extension.
+// output directory. The result always carries the target extension.
 func CalcConvertOutputPath(input, targetExt, outputDir string) string {
 	if outputDir != "" {
-		return filepath.Join(outputDir, filepath.Base(input))
+		return filepath.Join(outputDir, ConvertOutputPath(filepath.Base(input), targetExt))
 	}
 
 	return ConvertOutputPath(input, targetExt)
@@ -256,4 +268,128 @@ func MaybeReplaceOrRemove(compressed, original string) {
 	} else {
 		RemoveInPlace(original)
 	}
+}
+
+// ExpandInputs turns CLI arguments into a flat list of file paths.
+//
+// Glob patterns are expanded (recursive "**" patterns when recursive is set),
+// and directories are replaced by the files they contain: their immediate
+// children by default, or the whole tree when recursive is set. When exts is
+// non-empty only files with one of those extensions are kept from expanded
+// directories, so a stray .DS_Store never becomes an "unsupported format"
+// warning. Explicit file arguments are passed through untouched so a missing
+// file is still reported by the caller.
+func ExpandInputs(args []string, recursive bool, exts []string) []string {
+	var result []string
+
+	for _, path := range ResolveGlobs(args, recursive) {
+		info, err := os.Stat(path)
+		if err != nil || !info.IsDir() {
+			result = append(result, path)
+
+			continue
+		}
+
+		result = append(result, listDir(path, recursive, exts)...)
+	}
+
+	return result
+}
+
+func listDir(dir string, recursive bool, exts []string) []string {
+	var files []string
+
+	keep := func(path string) {
+		if len(exts) == 0 ||
+			slices.Contains(exts, strings.ToLower(strings.TrimPrefix(filepath.Ext(path), "."))) {
+			files = append(files, path)
+		}
+	}
+
+	if !recursive {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				keep(filepath.Join(dir, entry.Name()))
+			}
+		}
+
+		return files
+	}
+
+	//nolint:nilerr // Unreadable entries are skipped, not fatal.
+	_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+
+		if !d.IsDir() {
+			keep(path)
+		}
+
+		return nil
+	})
+
+	return files
+}
+
+// CopyFile copies src to dst, creating or truncating dst.
+func CopyFile(src, dst string) error {
+	source, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer source.Close() //nolint:errcheck
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(out, source)
+	if err != nil {
+		_ = out.Close()
+
+		return err
+	}
+
+	return out.Close()
+}
+
+// Describe renders a command the way a user would type it: program name
+// followed by its arguments, quoting any argument that contains whitespace.
+func Describe(cmd *exec.Cmd) string {
+	parts := make([]string, 0, len(cmd.Args))
+
+	for idx, arg := range cmd.Args {
+		if idx == 0 {
+			arg = filepath.Base(arg)
+		}
+
+		if strings.ContainsAny(arg, " \t'\"") {
+			arg = fmt.Sprintf("%q", arg)
+		}
+
+		parts = append(parts, arg)
+	}
+
+	return strings.Join(parts, " ")
+}
+
+// MagickBin returns the ImageMagick executable to use: "magick" (v7),
+// "convert" (v6), or "" when neither is installed.
+func MagickBin() string {
+	if HasTool("magick") {
+		return "magick"
+	}
+
+	if HasTool("convert") {
+		return "convert"
+	}
+
+	return ""
 }

--- a/internal/util/file_test.go
+++ b/internal/util/file_test.go
@@ -2,7 +2,9 @@
 package util
 
 import (
+	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 )
@@ -240,5 +242,125 @@ func TestInPlaceHint(t *testing.T) {
 
 	if got := InPlaceHint(false); got != "" {
 		t.Errorf("InPlaceHint(false) = %q; want \"\"", got)
+	}
+}
+
+// TestCalcConvertOutputPath tests that the target extension is kept with and
+// without an output directory.
+func TestCalcConvertOutputPath(t *testing.T) {
+	tests := []struct{ input, target, outDir, want string }{
+		{"photo.heic", "jpg", "", "photo.jpg"},
+		{"/a/photo.heic", "jpg", "out", filepath.Join("out", "photo.jpg")},
+		{"clip.mov", "mp4", "/tmp/x", "/tmp/x/clip.mp4"},
+	}
+	for _, testCase := range tests {
+		got := CalcConvertOutputPath(testCase.input, testCase.target, testCase.outDir)
+		if got != testCase.want {
+			t.Errorf("CalcConvertOutputPath(%q, %q, %q) = %q; want %q",
+				testCase.input, testCase.target, testCase.outDir, got, testCase.want)
+		}
+	}
+}
+
+// TestCalcOutputPathExt tests suffixed output paths with a new extension.
+func TestCalcOutputPathExt(t *testing.T) {
+	if got := CalcOutputPathExt("track.wav", "small", "m4a", ""); got != "track-small.m4a" {
+		t.Errorf("CalcOutputPathExt = %q; want track-small.m4a", got)
+	}
+
+	want := filepath.Join("out", "track.m4a")
+	if got := CalcOutputPathExt("/x/track.wav", "small", "m4a", "out"); got != want {
+		t.Errorf("CalcOutputPathExt with outDir = %q; want %q", got, want)
+	}
+}
+
+// TestExpandInputs tests glob, directory and extension filtering behavior.
+func TestExpandInputs(t *testing.T) {
+	dir := t.TempDir()
+	write := func(rel string) {
+		path := filepath.Join(dir, rel)
+		//nolint:errcheck
+		os.MkdirAll(filepath.Dir(path), 0o755)
+		//nolint:errcheck
+		os.WriteFile(path, nil, 0o644)
+	}
+
+	write("a.png")
+	write("b.jpg")
+	write("notes.txt")
+	write("nested/c.png")
+	write("nested/deeper/d.PNG")
+
+	images := []string{"png", "jpg"}
+
+	tests := []struct {
+		name      string
+		args      []string
+		recursive bool
+		exts      []string
+		want      int
+	}{
+		{"dir shallow filtered", []string{dir}, false, images, 2},
+		{"dir recursive filtered", []string{dir}, true, images, 4},
+		{"dir shallow unfiltered", []string{dir}, false, nil, 3},
+		{"glob", []string{filepath.Join(dir, "*.png")}, false, images, 1},
+		{"recursive glob", []string{filepath.Join(dir, "**", "*.png")}, true, images, 2},
+		{
+			"missing file passes through",
+			[]string{filepath.Join(dir, "missing.png")},
+			false,
+			images,
+			1,
+		},
+		{"no match", []string{filepath.Join(dir, "*.gif")}, false, images, 0},
+	}
+	for _, testCase := range tests {
+		got := ExpandInputs(testCase.args, testCase.recursive, testCase.exts)
+		if len(got) != testCase.want {
+			t.Errorf(
+				"%s: ExpandInputs = %d results %v; want %d",
+				testCase.name,
+				len(got),
+				got,
+				testCase.want,
+			)
+		}
+	}
+}
+
+// TestDescribe tests the human-readable command rendering used by dry runs.
+func TestDescribe(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "ffmpeg", "-i", "my clip.mov", "-y", "out.mp4")
+
+	want := `ffmpeg -i "my clip.mov" -y out.mp4`
+	if got := Describe(cmd); got != want {
+		t.Errorf("Describe = %q; want %q", got, want)
+	}
+}
+
+// TestCopyFile tests CopyFile.
+func TestCopyFile(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "sub", "dst.bin")
+
+	//nolint:errcheck
+	os.WriteFile(src, []byte("payload"), 0o644)
+	//nolint:errcheck
+	os.MkdirAll(filepath.Dir(dst), 0o755)
+
+	err := CopyFile(src, dst)
+	if err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(dst)
+	if string(data) != "payload" {
+		t.Errorf("CopyFile content = %q; want payload", data)
+	}
+
+	err = CopyFile(filepath.Join(dir, "nope"), dst)
+	if err == nil {
+		t.Error("CopyFile of missing source should fail")
 	}
 }


### PR DESCRIPTION
This PR adds the shared packages that the compress, convert and archive commands will be rebuilt on in the following PRs. Nothing is wired up yet, so behaviour is unchanged except for one path fix.

## What changed

- \`internal/format\`: one place for extensions, categories, conversion targets and the codec chosen per container. Today these lists are duplicated across info, compress and convert.
- \`internal/ffmpeg\`: builds ffmpeg encode and remux argument lists (VP9 gets \`-b:v 0\`, x264/x265 get \`-preset\` and \`yuv420p\`, mp4/mov get \`+faststart\`) and reads ffprobe metadata.
- \`internal/job\`: the per-file pipeline every command currently hand-rolls. Existence check, dry-run preview of the exact commands, spinner, steps, size report, in-place replacement, partial-output cleanup, summary, and an error when any file failed so the CLI can exit 1.
- \`util\`: \`ExpandInputs\` (globs and directories filtered by extension), \`CopyFile\`, \`Describe\`, \`MagickBin\`.
- Fix: \`CalcConvertOutputPath\` keeps the target extension when \`--output\` is set. Previously \`uts image convert x.heic --to jpg -o out\` wrote \`out/x.heic\`.

## Why

Nine functions repeat the same 60-line loop with small inconsistencies (some check tools, some do not, none return errors, so failures exit 0). Landing the shared code first keeps each follow-up PR a readable rewrite of one package.

## How to test

\`\`\`bash
just lint && just test-all
uts image convert photo.heic --to jpg -o out   # writes out/photo.jpg
\`\`\`