### PR TITLE
fix(compress): rebuild compress on the shared runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ You don't need to install all of them – `uts` will intelligently work with wha
 
 - **Batch processing**: Combine with the `-r` (or `--recursive`) flag to process entire directory trees.
 - **Dry‑run preview**: Use `-n` (or `--dry-run`) to see exactly what commands would be executed, without making any changes.
-- **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file.
+- **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in.
 - **Custom output directory**: Use `-o` (or `--output`) to specify where results are saved.
 
 For a complete reference, check out the [CLI Guide](docs/CLI.md).

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -69,7 +69,7 @@ The `-q, --quality` flag converts high-level presets (`low`, `medium`, `high`) t
 
 ### Video Commands
 
-Compression uses `ffmpeg` with `libx265` to output highly compressed HEVC files.
+Compression uses `ffmpeg` and keeps the input container: mp4/mov/avi/flv are encoded with H.264, mkv with H.265, and webm with VP9 (constant quality mode).
 
 ```bash
 # Compress using low quality preset (smaller file)
@@ -155,10 +155,10 @@ uts pdf convert page1.png page2.png page3.jpg --to pdf
 
 ### Audio Commands
 
-Processes file compression and bitrates through `ffmpeg`:
+Processes file compression and bitrates through `ffmpeg`. Lossy inputs (`mp3`, `ogg`, `opus`, `m4a`) are re-encoded in their own format, while lossless inputs (`wav`, `flac`) and everything else become AAC in an `.m4a` container:
 
 ```bash
-# Compress WAV file down to small audio profile
+# Compress WAV file down to small audio profile (writes podcast-small.m4a)
 uts audio compress podcast.wav -q low
 
 # Convert audio format to MP3
@@ -212,7 +212,10 @@ uts convert pdf report.pdf --to jpg
 
 - **Default suffix**: Unless `--in-place` is specified, files are written as `<name>-small.<ext>` in the source directory.
 - **Output directories**: When `--output <dir>` is set, target files are written to the destination directory. Suffixes are omitted if output name collisions do not occur.
+- **Not smaller**: When a compressed result is not smaller than the original, `uts` says so. With `--in-place` the original is kept and the result discarded.
 - **Priority**: If both `--output` and `--in-place` are defined, `--in-place` is ignored to prevent accidental source deletions.
+- **Failures**: A failed step removes its partial output, every remaining file is still processed, and `uts` exits `1`.
+- **Dry run**: `--dry-run` prints the exact external commands that would run for each file.
 
 ---
 

--- a/internal/compress/audio.go
+++ b/internal/compress/audio.go
@@ -1,11 +1,13 @@
+//nolint:goconst
 package compress
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
 
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/ffmpeg"
+	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/job"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/util"
 )
@@ -19,96 +21,48 @@ type AudioOptions struct {
 	DryRun    bool
 }
 
-// Audio compresses audio files using ffmpeg.
+// Audio compresses audio files using ffmpeg. Lossy inputs keep their format;
+// lossless inputs (wav, flac) become AAC in an .m4a container.
 func Audio(opts AudioOptions) error {
 	bitrate, err := util.AudioBitrate(opts.Quality)
 	if err != nil {
 		return err
 	}
 
-	if !util.HasTool("ffmpeg") {
-		return derrors.New(
-			derrors.CodeToolNotFound,
-			"ffmpeg not found — install: brew install ffmpeg",
-		)
+	err = ffmpeg.Check()
+	if err != nil {
+		return err
 	}
 
-	ui.Message.Infof(
-		"Audio compression at %s quality (bitrate=%s, codec=aac)",
-		opts.Quality,
-		bitrate,
-	)
-	total := len(opts.Files)
+	ui.Message.Infof("Audio compression at %s quality (bitrate=%s)", opts.Quality, bitrate)
 
-	for idx, file := range opts.Files {
-		if !util.FileExists(file) {
-			ui.Message.Warnf("File not found: %s", file)
-
-			continue
-		}
-
-		out := util.CalcOutputPath(file, "small", opts.OutputDir)
-		origSize := util.FileSize(file)
-
-		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
-
-		if opts.DryRun {
-			ui.Message.Infof(
-				"[dry-run] Would compress %s -> %s (bitrate=%s)%s",
-				file,
-				out,
-				bitrate,
-				util.InPlaceHint(opts.InPlace),
+	return job.Run(opts.Files, job.Options{
+		Verb:    "Compressing",
+		Done:    "Compressed",
+		Noun:    "audio files",
+		Compare: true,
+		InPlace: opts.InPlace,
+		DryRun:  opts.DryRun,
+		Code:    derrors.CodeCompressionFailed,
+	}, func(file string) (*job.Job, error) {
+		ext := format.Ext(file)
+		if format.Classify(ext) != format.Audio {
+			return nil, derrors.Newf(
+				derrors.CodeUnsupportedFormat,
+				"unsupported audio format .%s",
+				ext,
 			)
-
-			continue
 		}
 
-		err := util.EnsureDir(out)
-		if err != nil {
-			ui.Message.Errorf("Failed to create output directory: %v", err)
+		codec, outExt := format.AudioCompressTarget(ext)
+		out := util.CalcOutputPathExt(file, "small", outExt, opts.OutputDir)
 
-			continue
-		}
-
-		spinner := ui.NewSpinner(nil, 0)
-		spinner.SetSuffix(fmt.Sprintf("Compressing %s...", file))
-		spinner.Start()
-
-		cmd := exec.CommandContext(
-			context.Background(), "ffmpeg",
-			"-i", file,
-			"-c:a", "aac",
-			"-b:a", bitrate,
-			"-y", out,
-		)
-		output, err := cmd.CombinedOutput()
-
-		spinner.Stop()
-
-		if err == nil && util.FileExists(out) {
-			newSize := util.FileSize(out)
-			ratio := util.CompressionRatio(origSize, newSize)
-			ui.Message.Successf(
-				"%s: %s → %s %s",
-				file,
-				util.HumanSize(origSize),
-				util.HumanSize(newSize),
-				ratio,
-			)
-
-			if opts.InPlace {
-				util.MaybeReplaceOrRemove(out, file)
-			}
-		} else {
-			ui.Message.Errorf("Compression failed: %s", file)
-			ui.Message.Mutedf("ffmpeg: %s", string(output))
-		}
-	}
-
-	if total > 1 {
-		ui.Message.Successf("Compressed %d audio files", total)
-	}
-
-	return nil
+		return &job.Job{
+			Input:  file,
+			Output: out,
+			Steps: []job.Step{job.Exec("ffmpeg",
+				"-i", file, "-vn", "-c:a", codec, "-b:a", bitrate, "-y", out)},
+			Note: fmt.Sprintf("%s %s → .%s", codec, bitrate, outExt),
+		}, nil
+	})
 }

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -1,21 +1,21 @@
-//nolint:mnd
+//nolint:mnd,goconst
 package compress
 
 import (
-	"context"
 	"fmt"
-	"os"
-	"os/exec"
-	"path/filepath"
 	"strconv"
-	"strings"
 
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/job"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/util"
 )
 
-var errImageMagick = derrors.New(derrors.CodeToolNotFound, "imagemagick not found")
+var errImageMagick = derrors.New(
+	derrors.CodeToolNotFound,
+	"ImageMagick not found — install: brew install imagemagick",
+)
 
 // ImageOptions represents options for image compression.
 type ImageOptions struct {
@@ -26,240 +26,143 @@ type ImageOptions struct {
 	DryRun    bool
 }
 
-// Image compresses image files using various tools.
+// Image compresses image files using the best tool available per format.
 func Image(opts ImageOptions) error {
-	qualityVal, err := util.PresetVal(opts.Quality, 60, 80, 90)
+	quality, err := util.PresetVal(opts.Quality, 60, 80, 90)
 	if err != nil {
 		return err
 	}
 
-	ui.Message.Infof("Image compression at %s quality (value=%d)", opts.Quality, qualityVal)
-	total := len(opts.Files)
+	ui.Message.Infof("Image compression at %s quality (value=%d)", opts.Quality, quality)
 
-	for idx, file := range opts.Files {
-		if !util.FileExists(file) {
-			ui.Message.Warnf("File not found: %s", file)
-
-			continue
-		}
-
-		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(file), "."))
-		out := util.CalcOutputPath(file, "small", opts.OutputDir)
-		origSize := util.FileSize(file)
-
-		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
-
-		if opts.DryRun {
-			ui.Message.Infof(
-				"[dry-run] Would compress %s -> %s (format=%s, quality=%d)%s",
-				file,
-				out,
-				ext,
-				qualityVal,
-				util.InPlaceHint(opts.InPlace),
-			)
-
-			continue
-		}
-
-		err := util.EnsureDir(out)
-		if err != nil {
-			ui.Message.Errorf("Failed to create output directory: %v", err)
-
-			continue
-		}
-
-		spinner := ui.NewSpinner(nil, 0)
-		spinner.SetSuffix(fmt.Sprintf("Compressing %s...", file))
-		spinner.Start()
-
-		var compressOK bool
-		switch ext {
-		case "png":
-			compressOK = compressPNG(file, out, qualityVal) == nil
-		case "jpg", "jpeg":
-			compressOK = compressJPEG(file, out, qualityVal) == nil
-		case "webp":
-			compressOK = compressWebP(file, out, qualityVal) == nil
-		case "gif":
-			compressOK = compressGIF(file, out) == nil
-		case "bmp", "tiff", "tif":
-			compressOK = compressGeneric(file, out, qualityVal) == nil
-		case "heic", "heif":
-			out = strings.TrimSuffix(out, filepath.Ext(out)) + ".jpg"
-			compressOK = compressHEIC(file, out, qualityVal) == nil
-		case "avif", "avifs":
-			out = strings.TrimSuffix(out, filepath.Ext(out)) + ".avif"
-			compressOK = compressAVIF(file, out, qualityVal) == nil
-		default:
-			ui.Message.Warnf("Unsupported image format: %s — skipping %s", ext, file)
-			spinner.Stop()
-
-			continue
-		}
-
-		spinner.Stop()
-
-		if compressOK && util.FileExists(out) {
-			newSize := util.FileSize(out)
-			ratio := util.CompressionRatio(origSize, newSize)
-			ui.Message.Successf(
-				"%s: %s → %s %s",
-				file,
-				util.HumanSize(origSize),
-				util.HumanSize(newSize),
-				ratio,
-			)
-
-			if opts.InPlace {
-				util.MaybeReplaceOrRemove(out, file)
-			}
-		} else {
-			ui.Message.Errorf("Compression failed: %s", file)
-		}
-	}
-
-	if total > 1 {
-		ui.Message.Successf("Compressed %d image files", total)
-	}
-
-	return nil
+	return job.Run(opts.Files, job.Options{
+		Verb:    "Compressing",
+		Done:    "Compressed",
+		Noun:    "image files",
+		Compare: true,
+		InPlace: opts.InPlace,
+		DryRun:  opts.DryRun,
+		Code:    derrors.CodeCompressionFailed,
+	}, func(file string) (*job.Job, error) {
+		return planImage(file, quality, opts.OutputDir)
+	})
 }
 
-func compressPNG(file, out string, quality int) error {
-	if util.HasTool("pngquant") {
-		ui.Message.Mutedf("Using pngquant")
+func planImage(file string, quality int, outputDir string) (*job.Job, error) {
+	ext := format.Ext(file)
+	out := util.CalcOutputPath(file, "small", outputDir)
 
-		cmd := exec.CommandContext(context.Background(), "pngquant",
-			fmt.Sprintf("--quality=%d-%d", quality-10, quality),
-			"--speed", "1", "--strip", "--output", out, "--", file)
+	var (
+		tool  string
+		steps []job.Step
+		err   error
+	)
 
-		err := cmd.Run()
-		if err != nil {
-			return err
-		}
-
-		if util.HasTool("optipng") && util.FileExists(out) {
-			ui.Message.Mutedf("Optimizing with optipng")
-
-			_ = exec.CommandContext(context.Background(), "optipng", "-quiet", "-o2", out).Run()
-		}
-
-		return nil
+	switch ext {
+	case "png":
+		tool, steps, err = pngSteps(file, out, quality)
+	case "jpg", "jpeg":
+		tool, steps, err = jpegSteps(file, out, quality)
+	case "webp":
+		tool, steps, err = webpSteps(file, out, quality)
+	case "gif":
+		tool, steps, err = gifSteps(file, out)
+	case "heic", "heif":
+		// HEIC has no lossy re-encoder in common toolchains; JPEG is the
+		// portable result users expect from "compress this photo".
+		out = util.CalcOutputPathExt(file, "small", "jpg", outputDir)
+		tool, steps, err = heicSteps(file, out, quality)
+	case "bmp", "tiff", "tif", "avif", "avifs":
+		tool, steps, err = magickSteps(file, out, quality)
+	default:
+		return nil, derrors.Newf(derrors.CodeUnsupportedFormat, "unsupported image format .%s", ext)
 	}
 
-	if util.HasTool("optipng") {
-		ui.Message.Mutedf("Using optipng")
-
-		err := copyFile(file, out)
-		if err != nil {
-			return err
-		}
-
-		return exec.CommandContext(context.Background(), "optipng", "-quiet", "-o2", out).Run()
+	if err != nil {
+		return nil, err
 	}
 
-	return magickCmd(file, out, quality)
+	return &job.Job{Input: file, Output: out, Steps: steps, Note: "via " + tool}, nil
 }
 
-func compressJPEG(file, out string, quality int) error {
+func pngSteps(file, out string, quality int) (string, []job.Step, error) {
+	switch {
+	case util.HasTool("pngquant"):
+		steps := []job.Step{job.Exec("pngquant",
+			fmt.Sprintf("--quality=%d-%d", max(quality-10, 0), quality),
+			"--speed", "1", "--strip", "--force", "--output", out, "--", file)}
+		tool := "pngquant"
+
+		if util.HasTool("optipng") {
+			steps = append(steps, job.Exec("optipng", "-quiet", "-o2", out))
+			tool += " + optipng"
+		}
+
+		return tool, steps, nil
+	case util.HasTool("optipng"):
+		return "optipng", []job.Step{
+			copyStep(file, out),
+			job.Exec("optipng", "-quiet", "-o2", out),
+		}, nil
+	}
+
+	return magickSteps(file, out, quality)
+}
+
+func jpegSteps(file, out string, quality int) (string, []job.Step, error) {
 	if util.HasTool("jpegoptim") {
-		ui.Message.Mutedf("Using jpegoptim")
-
-		err := copyFile(file, out)
-		if err != nil {
-			return err
-		}
-
-		return exec.CommandContext(context.Background(), "jpegoptim", fmt.Sprintf("--max=%d", quality), "--strip-all", "--quiet", out).
-			Run()
+		return "jpegoptim", []job.Step{
+			copyStep(file, out),
+			job.Exec("jpegoptim", fmt.Sprintf("--max=%d", quality), "--strip-all", "--quiet", out),
+		}, nil
 	}
 
-	return magickCmd(file, out, quality)
+	return magickSteps(file, out, quality)
 }
 
-func compressWebP(file, out string, quality int) error {
+func webpSteps(file, out string, quality int) (string, []job.Step, error) {
 	if util.HasTool("cwebp") {
-		ui.Message.Mutedf("Using cwebp")
-
-		return exec.CommandContext(context.Background(), "cwebp", "-q", strconv.Itoa(quality), "-m", "6", file, "-o", out).
-			Run()
+		return "cwebp", []job.Step{
+			job.Exec("cwebp", "-quiet", "-q", strconv.Itoa(quality), "-m", "6", file, "-o", out),
+		}, nil
 	}
 
-	return magickCmd(file, out, quality)
+	return magickSteps(file, out, quality)
 }
 
-func compressGIF(file, out string) error {
+func gifSteps(file, out string) (string, []job.Step, error) {
 	if util.HasTool("gifsicle") {
-		ui.Message.Mutedf("Using gifsicle")
-
-		return exec.CommandContext(context.Background(), "gifsicle", "-O3", "--lossy=80", file, "-o", out).
-			Run()
+		return "gifsicle", []job.Step{
+			job.Exec("gifsicle", "-O3", "--lossy=80", file, "-o", out),
+		}, nil
 	}
 
-	return magickCmd(file, out, 80)
+	return magickSteps(file, out, 80)
 }
 
-func compressGeneric(file, out string, quality int) error {
-	return magickCmd(file, out, quality)
-}
-
-func compressHEIC(file, out string, quality int) error {
+func heicSteps(file, out string, quality int) (string, []job.Step, error) {
 	if util.HasTool("heif-convert") {
-		ui.Message.Mutedf("Using heif-convert")
-
-		return exec.CommandContext(context.Background(), "heif-convert", "-q", strconv.Itoa(quality), file, out).
-			Run()
+		return "heif-convert", []job.Step{
+			job.Exec("heif-convert", "-q", strconv.Itoa(quality), file, out),
+		}, nil
 	}
 
-	return magickCmd(file, out, quality)
+	return magickSteps(file, out, quality)
 }
 
-func compressAVIF(file, out string, quality int) error {
-	if util.HasTool("cavif") {
-		ui.Message.Mutedf("Using cavif")
-
-		return exec.CommandContext(context.Background(), "cavif", "-q", strconv.Itoa(quality), "-s", "6", "-o", out, file).
-			Run()
+func magickSteps(file, out string, quality int) (string, []job.Step, error) {
+	bin := util.MagickBin()
+	if bin == "" {
+		return "", nil, errImageMagick
 	}
 
-	if util.HasTool("avifenc") {
-		ui.Message.Mutedf("Using avifenc")
-
-		quantizer := (100 - quality) * 63 / 100
-
-		return exec.CommandContext(context.Background(), "avifenc", "--min", "0", "--max", strconv.Itoa(quantizer), "-s", "6", file, out).
-			Run()
-	}
-
-	return magickCmd(file, out, quality)
+	return "ImageMagick", []job.Step{
+		job.Exec(bin, file, "-quality", strconv.Itoa(quality), "-strip", out),
+	}, nil
 }
 
-func magickCmd(input, output string, quality int) error {
-	if util.HasTool("magick") {
-		ui.Message.Mutedf("Using ImageMagick")
-
-		return exec.CommandContext(context.Background(), "magick", input, "-quality", strconv.Itoa(quality), "-strip", output).
-			Run()
-	}
-
-	if util.HasTool("convert") {
-		ui.Message.Mutedf("Using ImageMagick (convert)")
-
-		return exec.CommandContext(context.Background(), "convert", input, "-quality", strconv.Itoa(quality), "-strip", output).
-			Run()
-	}
-
-	ui.Message.Errorf("ImageMagick not found — install: brew install imagemagick")
-
-	return errImageMagick
-}
-
-func copyFile(src, dst string) error {
-	input, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-
-	return os.WriteFile(dst, input, 0o644)
+func copyStep(src, dst string) job.Step {
+	return job.Do(fmt.Sprintf("copy %s -> %s", src, dst), func() error {
+		return util.CopyFile(src, dst)
+	})
 }

--- a/internal/compress/pdf.go
+++ b/internal/compress/pdf.go
@@ -1,10 +1,12 @@
+//nolint:goconst
 package compress
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
 
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/job"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/util"
 )
@@ -25,6 +27,13 @@ func PDF(opts PDFOptions) error {
 		return err
 	}
 
+	if !util.HasTool("gs") {
+		return derrors.New(
+			derrors.CodeToolNotFound,
+			"ghostscript not found — install: brew install ghostscript",
+		)
+	}
+
 	if settings != "" {
 		ui.Message.Infof(
 			"PDF compression at %s quality (preset=%s, %d DPI)",
@@ -36,35 +45,24 @@ func PDF(opts PDFOptions) error {
 		ui.Message.Infof("PDF compression at %s quality (%d DPI)", opts.Quality, dpi)
 	}
 
-	total := len(opts.Files)
-	for idx, file := range opts.Files {
-		if !util.FileExists(file) {
-			ui.Message.Warnf("File not found: %s", file)
-
-			continue
+	return job.Run(opts.Files, job.Options{
+		Verb:    "Compressing",
+		Done:    "Compressed",
+		Noun:    "PDF files",
+		Compare: true,
+		InPlace: opts.InPlace,
+		DryRun:  opts.DryRun,
+		Code:    derrors.CodeCompressionFailed,
+	}, func(file string) (*job.Job, error) {
+		if format.Ext(file) != "pdf" {
+			return nil, derrors.Newf(
+				derrors.CodeUnsupportedFormat,
+				"not a PDF: .%s",
+				format.Ext(file),
+			)
 		}
 
 		out := util.CalcOutputPath(file, "small", opts.OutputDir)
-		origSize := util.FileSize(file)
-
-		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
-
-		if opts.DryRun {
-			ui.Message.Infof("[dry-run] Would compress %s -> %s (settings=%s)", file, out, settings)
-
-			continue
-		}
-
-		err := util.EnsureDir(out)
-		if err != nil {
-			ui.Message.Errorf("Failed to create output directory: %v", err)
-
-			continue
-		}
-
-		spinner := ui.NewSpinner(nil, 0)
-		spinner.SetSuffix(fmt.Sprintf("Compressing %s...", file))
-		spinner.Start()
 
 		args := []string{
 			"-sDEVICE=pdfwrite",
@@ -77,42 +75,18 @@ func PDF(opts PDFOptions) error {
 			args = append(args, "-dPDFSETTINGS="+settings)
 		}
 
-		args = append(
-			args,
+		args = append(args,
 			fmt.Sprintf("-dColorImageResolution=%d", dpi),
 			fmt.Sprintf("-dGrayImageResolution=%d", dpi),
 			fmt.Sprintf("-dMonoImageResolution=%d", dpi),
 			"-sOutputFile="+out, file,
 		)
 
-		cmd := exec.CommandContext(context.Background(), "gs", args...)
-		output, err := cmd.CombinedOutput()
-
-		spinner.Stop()
-
-		if err == nil && util.FileExists(out) {
-			newSize := util.FileSize(out)
-			ratio := util.CompressionRatio(origSize, newSize)
-			ui.Message.Successf(
-				"%s: %s → %s %s",
-				file,
-				util.HumanSize(origSize),
-				util.HumanSize(newSize),
-				ratio,
-			)
-
-			if opts.InPlace {
-				util.MaybeInPlace(out, file)
-			}
-		} else {
-			ui.Message.Errorf("Compression failed: %s", file)
-			ui.Message.Mutedf("gs: %s", string(output))
-		}
-	}
-
-	if total > 1 {
-		ui.Message.Successf("Compressed %d PDF files", total)
-	}
-
-	return nil
+		return &job.Job{
+			Input:  file,
+			Output: out,
+			Steps:  []job.Step{job.Exec("gs", args...)},
+			Note:   "via ghostscript",
+		}, nil
+	})
 }

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -1,13 +1,13 @@
+//nolint:goconst
 package compress
 
 import (
-	"context"
 	"fmt"
-	"os/exec"
-	"path/filepath"
-	"strconv"
 
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/ffmpeg"
+	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/job"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/util"
 )
@@ -21,18 +21,16 @@ type VideoOptions struct {
 	DryRun    bool
 }
 
-// Video compresses video files using ffmpeg.
+// Video compresses video files using ffmpeg, keeping the input container.
 func Video(opts VideoOptions) error {
 	crf, preset, err := util.VideoQuality(opts.Quality)
 	if err != nil {
 		return err
 	}
 
-	if !util.HasTool("ffmpeg") {
-		return derrors.New(
-			derrors.CodeToolNotFound,
-			"ffmpeg not found — install: brew install ffmpeg",
-		)
+	err = ffmpeg.Check()
+	if err != nil {
+		return err
 	}
 
 	ui.Message.Infof(
@@ -42,84 +40,34 @@ func Video(opts VideoOptions) error {
 		preset,
 	)
 
-	total := len(opts.Files)
-	for idx, file := range opts.Files {
-		if !util.FileExists(file) {
-			ui.Message.Warnf("File not found: %s", file)
-
-			continue
+	return job.Run(opts.Files, job.Options{
+		Verb:    "Compressing",
+		Done:    "Compressed",
+		Noun:    "video files",
+		Compare: true,
+		InPlace: opts.InPlace,
+		DryRun:  opts.DryRun,
+		Code:    derrors.CodeCompressionFailed,
+	}, func(file string) (*job.Job, error) {
+		ext := format.Ext(file)
+		if format.Classify(ext) != format.Video {
+			return nil, derrors.Newf(
+				derrors.CodeUnsupportedFormat,
+				"unsupported video format .%s",
+				ext,
+			)
 		}
 
 		out := util.CalcOutputPath(file, "small", opts.OutputDir)
-		origSize := util.FileSize(file)
+		vcodec, acodec := format.VideoCodecs(ext)
 
-		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
-
-		if opts.DryRun {
-			ui.Message.Infof(
-				"[dry-run] Would compress %s -> %s (crf=%d, preset=%s)%s",
-				file,
-				out,
-				crf,
-				preset,
-				util.InPlaceHint(opts.InPlace),
-			)
-
-			continue
-		}
-
-		err := util.EnsureDir(out)
-		if err != nil {
-			ui.Message.Errorf("Failed to create output directory: %v", err)
-
-			continue
-		}
-
-		spinner := ui.NewSpinner(nil, 0)
-		spinner.SetSuffix(fmt.Sprintf("Compressing %s...", file))
-		spinner.Start()
-
-		ext := filepath.Ext(file)
-		vcodec, acodec := util.VideoCodecs(ext)
-
-		cmd := exec.CommandContext(
-			context.Background(), "ffmpeg",
-			"-i", file,
-			"-vcodec", vcodec,
-			"-crf", strconv.Itoa(crf),
-			"-preset", preset,
-			"-acodec", acodec,
-			"-b:a", "128k",
-			"-movflags", "+faststart",
-			"-y", out,
-		)
-		output, err := cmd.CombinedOutput()
-
-		spinner.Stop()
-
-		if err == nil && util.FileExists(out) {
-			newSize := util.FileSize(out)
-			ratio := util.CompressionRatio(origSize, newSize)
-			ui.Message.Successf(
-				"%s: %s → %s %s",
-				file,
-				util.HumanSize(origSize),
-				util.HumanSize(newSize),
-				ratio,
-			)
-
-			if opts.InPlace {
-				util.MaybeReplaceOrRemove(out, file)
-			}
-		} else {
-			ui.Message.Errorf("Compression failed: %s", file)
-			ui.Message.Mutedf("ffmpeg: %s", string(output))
-		}
-	}
-
-	if total > 1 {
-		ui.Message.Successf("Compressed %d video files", total)
-	}
-
-	return nil
+		return &job.Job{
+			Input:  file,
+			Output: out,
+			Steps: []job.Step{
+				job.Exec("ffmpeg", ffmpeg.EncodeArgs(file, out, ext, crf, preset)...),
+			},
+			Note: fmt.Sprintf("%s/%s crf=%d", vcodec, acodec, crf),
+		}, nil
+	})
 }


### PR DESCRIPTION
This PR rebuilds image, video, audio and PDF compression on the shared runner from #37 and fixes the bugs that the old per-command loops hid.

## What changed

- **Audio compress produces valid files.** WAV inputs used to get AAC data inside a WAV container, and MP3 inputs failed outright and left a broken partial file. Lossy inputs (mp3, ogg, opus, m4a) now keep their format; lossless inputs (wav, flac) become AAC in `.m4a`, as the help text always claimed.
- **WebM compress no longer inflates files.** VP9 ignores `-crf` without `-b:v 0`; a test clip went from +77% to a real reduction.
- **Failures are failures.** A failed step removes its partial output, the remaining files still run, and the command exits 1. PDF compress now checks for Ghostscript up front.
- **Not-smaller guard.** When a result is not smaller than the original `uts` says so, and with `-i` the original is kept.
- `--dry-run` prints the exact external commands per file, and `-v` logs every command executed. Batch runs end with a summary of ok, skipped and failed counts plus bytes saved.

Docs: CLI reference updated for the audio output format, the codecs used per container, and the new output behaviour.

## Why

The four compress functions each hand-rolled the same loop with different gaps. Moving them onto one runner fixes the gaps once and makes the next PRs (convert, archive) small.

## How to test

```bash
just lint && just test-all
ffmpeg -f lavfi -i "sine=frequency=440:duration=2" tone.wav
uts audio compress tone.wav          # writes tone-small.m4a, plays anywhere
uts image compress missing.png; echo $?   # 1
uts video compress clip.mp4 -q low --dry-run   # shows the ffmpeg command
```