### PR TITLE
feat(cli): expand globs and directories, scope flags per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ uts audio convert track.wav --to mp3 -q high
 # Compress PDF document to a medium-res profile
 uts pdf compress draft.pdf -q medium
 
+# Compress every image in a folder tree
+uts image compress ./photos -r
+
 # Compress folder to a zstd tarball archive
 uts archive compress ./project/ --algorithm zstd
 
@@ -149,11 +152,12 @@ You don't need to install all of them – `uts` will intelligently work with wha
 
 ## Advanced Usage
 
-- **Batch processing**: Combine with the `-r` (or `--recursive`) flag to process entire directory trees.
-- **Dry‑run preview**: Use `-n` (or `--dry-run`) to see exactly what commands would be executed, without making any changes.
+- **Batch processing**: Pass files, directories, or quoted globs. A directory expands to the media files inside it, and `-r` (or `--recursive`) walks the whole tree.
+- **Dry‑run preview**: Use `-n` (or `--dry-run`) to print the exact commands that would run, without making any changes.
 - **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in.
 - **Custom output directory**: Use `-o` (or `--output`) to specify where results are saved.
 - **Lossless video conversion**: `video convert` copies the streams into the new container whenever the codecs allow, so `mov → mp4` takes a second and loses nothing. Pass `-q` to force a re-encode.
+- **Scripting**: `uts` exits `1` when any file fails, and `-v` logs every external command it runs.
 
 For a complete reference, check out the [CLI Guide](docs/CLI.md).
 

--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -9,6 +9,8 @@ import (
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"github.com/y3owk1n/uts/internal/archive"
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/util"
 )
 
 // archiveCmd represents the archive command.
@@ -18,7 +20,7 @@ var archiveCmd = &cobra.Command{
 	Short:   "Compress, extract, and list archives",
 	Long: `Compress, extract, and list archives.
 
-Supported algorithms: gzip, zstd, xz, brotli, zip
+Algorithms: ` + strings.Join(archive.Algorithms, ", ") + `
 Archive formats: zip, tar, tar.gz, tar.zst, tar.xz, tar.bz2, tar.br`,
 	Example: `  uts archive compress ./project/ --algorithm zstd
   uts archive extract backup.zip
@@ -32,21 +34,22 @@ Archive formats: zip, tar, tar.gz, tar.zst, tar.xz, tar.bz2, tar.br`,
 var archiveCompressCmd = &cobra.Command{
 	Use:     "compress",
 	Aliases: []string{"c"},
-	Short:   "Create compressed archives from files/directories",
-	Long: `Create compressed archives with the specified algorithm.
+	Short:   "Create a compressed archive from files/directories",
+	Long: `Create a compressed archive with the chosen algorithm.
 
 Algorithms: zip (default), gzip, zstd, xz, brotli.
-Output saved as <name>.tar.<algo> or <name>.zip.`,
+Output is named after the input: <name>.tar.<algo> or <name>.zip.`,
 	Example: `  uts archive compress ./project/ --algorithm zstd
   uts archive compress ./data/ --algorithm zip
+  uts archive compress notes.md photo.jpg -o ./backups/
   uts archive compress ./src/ --dry-run`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("compressing archives", "files", args, "algorithm", algorithm)
+		log.Debug("creating archive", "files", args, "algorithm", algorithm)
 
 		return archive.Create(archive.CreateOptions{
 			Files:     args,
-			Algorithm: strings.ToLower(algorithm),
+			Algorithm: algorithm,
 			OutputDir: outputDir,
 			DryRun:    dryRun,
 		})
@@ -58,19 +61,24 @@ var archiveExtractCmd = &cobra.Command{
 	Use:     "extract",
 	Aliases: []string{"x"},
 	Short:   "Extract archive contents",
-	Long: `Extract archive files to the specified directory.
+	Long: `Extract archives into the output directory (default: current directory).
 
 Supported formats: zip, tar, tar.gz, tar.zst, tar.xz, tar.bz2, tar.br`,
 	Example: `  uts archive extract backup.zip
-  uts archive extract project.tar.gz
+  uts archive extract project.tar.gz -o ./project/
   uts archive extract '*.tar.zst' -o ./output/
   uts archive extract backup.zip --dry-run`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("extracting archives", "files", args)
+		files, err := archiveInputs(args)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("extracting archives", "files", files)
 
 		return archive.Extract(archive.ExtractOptions{
-			Files:     args,
+			Files:     files,
 			OutputDir: outputDir,
 			DryRun:    dryRun,
 		})
@@ -82,7 +90,7 @@ var archiveListCmd = &cobra.Command{
 	Use:     "list",
 	Aliases: []string{"ls"},
 	Short:   "List archive contents",
-	Long: `List the contents of archive files without extracting.
+	Long: `List the contents of archives without extracting.
 
 Supported formats: zip, tar, tar.gz, tar.zst, tar.xz, tar.bz2, tar.br`,
 	Example: `  uts archive list backup.zip
@@ -90,15 +98,34 @@ Supported formats: zip, tar, tar.gz, tar.zst, tar.xz, tar.bz2, tar.br`,
   uts archive list '*.tar.zst'`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("listing archives", "files", args)
+		files, err := archiveInputs(args)
+		if err != nil {
+			return err
+		}
 
-		return archive.List(archive.ListOptions{
-			Files: args,
-		})
+		log.Debug("listing archives", "files", files)
+
+		return archive.List(archive.ListOptions{Files: files})
 	},
 }
 
+// archiveInputs resolves globs but never expands directories: an archive
+// command's inputs are the archives themselves.
+func archiveInputs(args []string) ([]string, error) {
+	files := util.ResolveGlobs(args, recursive)
+	if len(files) == 0 {
+		return nil, derrors.New(derrors.CodeFileNotFound, "no input files matched")
+	}
+
+	return files, nil
+}
+
 func init() {
+	archiveCompressCmd.Flags().StringVar(&algorithm, "algorithm", "zip",
+		"Archive algorithm: "+strings.Join(archive.Algorithms, ", "))
+	_ = archiveCompressCmd.RegisterFlagCompletionFunc("algorithm",
+		cobra.FixedCompletions(archive.Algorithms, cobra.ShellCompDirectiveNoFileComp))
+
 	archiveCmd.AddCommand(archiveCompressCmd)
 	archiveCmd.AddCommand(archiveExtractCmd)
 	archiveCmd.AddCommand(archiveListCmd)

--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -7,8 +7,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"github.com/y3owk1n/uts/internal/compress"
-	"github.com/y3owk1n/uts/internal/convert"
-	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
 )
 
 // audioCmd represents the audio command.
@@ -18,8 +17,8 @@ var audioCmd = &cobra.Command{
 	Short:   "Compress and convert audio files",
 	Long: `Compress and convert audio files using ffmpeg.
 
-Input formats: wav, flac, aac, mp3, m4a, opus, ogg, wma
-Output formats: mp3, aac, m4a, wav, flac, opus, ogg`,
+Input formats: ` + strings.Join(format.AudioExts, ", ") + `
+Output formats: ` + strings.Join(format.AudioTargets, ", "),
 	Example: `  uts audio compress podcast.wav -q low
   uts audio convert track.wav --to mp3`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -31,21 +30,28 @@ Output formats: mp3, aac, m4a, wav, flac, opus, ogg`,
 var audioCompressCmd = &cobra.Command{
 	Use:     "compress",
 	Aliases: []string{"c"},
-	Short:   "Compress audio files using ffmpeg (aac)",
-	Long: `Compress audio files using ffmpeg with AAC codec.
+	Short:   "Compress audio files using ffmpeg",
+	Long: `Compress audio files using ffmpeg.
 
-Quality: high (192k), medium (128k), low (96k), or raw kbps.
-Output saved as <name>-small.m4a.`,
+Lossy inputs (mp3, ogg, opus, m4a) are re-encoded in their own format.
+Lossless inputs (wav, flac) and everything else become AAC in .m4a.
+
+Quality: high (192k), medium (128k), low (96k), or raw kbps.`,
 	Example: `  uts audio compress podcast.wav -q low
   uts audio compress voice-memo.m4a -q high
   uts audio compress voice.wav -q 256 --dry-run
-  uts audio compress '*.wav' -r`,
+  uts audio compress ./recordings -r`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("compressing audio files", "files", args)
+		files, err := inputs(args, format.AudioExts)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("compressing audio files", "files", files)
 
 		return compress.Audio(compress.AudioOptions{
-			Files:     args,
+			Files:     files,
 			Quality:   quality,
 			OutputDir: outputDir,
 			InPlace:   inPlace,
@@ -54,41 +60,7 @@ Output saved as <name>-small.m4a.`,
 	},
 }
 
-// audioConvertCmd represents the audio convert command.
-var audioConvertCmd = &cobra.Command{
-	Use:     "convert",
-	Aliases: []string{"x"},
-	Short:   "Convert between audio formats",
-	Long: `Convert audio files (or extract audio from video) using ffmpeg.
-
-Target formats: mp3, aac, m4a, wav, flac, opus, ogg`,
-	Example: `  uts audio convert track.wav --to mp3
-  uts audio convert video.mp4 --to mp3
-  uts audio convert song.flac --to m4a -q high
-  uts audio convert '*.wav' --to mp3 -q 96
-  uts audio convert lecture.wav --to mp3`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(
-				derrors.CodeInvalidInput,
-				"missing --to <format>. Examples: --to mp3, --to wav, --to flac, --to aac",
-			)
-		}
-
-		log.Debug("converting audio files", "files", args, "target", targetFmt)
-
-		return convert.Audio(convert.AudioOptions{
-			Files:     args,
-			Target:    strings.ToLower(targetFmt),
-			Quality:   quality,
-			OutputDir: outputDir,
-			DryRun:    dryRun,
-		})
-	},
-}
-
 func init() {
 	audioCmd.AddCommand(audioCompressCmd)
-	audioCmd.AddCommand(audioConvertCmd)
+	audioCmd.AddCommand(newAudioConvertCmd("convert", []string{"x"}))
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -1,22 +1,24 @@
-//nolint:goconst
 package cmd
 
 import (
+	"slices"
 	"strings"
 
+	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"github.com/y3owk1n/uts/internal/convert"
-	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
 )
 
-// convertCmd represents the convert command.
+// convertCmd is the top-level alias: "uts convert image ..." behaves exactly
+// like "uts image convert ...".
 var convertCmd = &cobra.Command{
 	Use:     "convert",
 	Aliases: []string{"x"},
 	Short:   "Convert between formats",
 	Long: `Convert files between different formats (image, video, audio, pdf).
 
-Requires --to <format> flag to specify the target format.`,
+Requires --to <format> to specify the target format.`,
 	Example: `  uts convert image photo.heic --to jpg
   uts convert video clip.mov --to mp4
   uts convert audio track.wav --to mp3 -q 96
@@ -26,118 +28,178 @@ Requires --to <format> flag to specify the target format.`,
 	},
 }
 
-// convertImageCmd represents the convert image command.
-var convertImageCmd = &cobra.Command{
-	Use:     "image",
-	Aliases: []string{"img", "i"},
-	Short:   "Convert between image formats",
-	Long: `Convert image files between formats.
+func newImageConvertCmd(use string, aliases []string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   "Convert between image formats",
+		Long: `Convert image files between formats using ImageMagick (or sips on macOS).
 
-Target formats: jpg, png, webp, gif, bmp, tiff, avif`,
-	Example: `  uts convert image photo.heic --to jpg
-  uts convert image screenshot.png --to webp -q 85
-  uts convert image '*.heic' --to jpg`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(derrors.CodeInvalidInput, "missing --to <format>")
-		}
+Target formats: ` + strings.Join(format.ImageTargets, ", "),
+		Example: `  uts image convert photo.heic --to jpg
+  uts image convert screenshot.png --to webp -q high
+  uts image convert photo.jpg --to avif -q 70
+  uts image convert ./photos --to jpg -r`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := requireTarget(format.ImageTargets)
+			if err != nil {
+				return err
+			}
 
-		return convert.Image(convert.ImageOptions{
-			Files:     args,
-			Target:    strings.ToLower(targetFmt),
-			Quality:   quality,
-			OutputDir: outputDir,
-			InPlace:   inPlace,
-			DryRun:    dryRun,
-		})
-	},
+			files, err := inputs(args, format.ImageExts)
+			if err != nil {
+				return err
+			}
+
+			log.Debug("converting image files", "files", files, "target", targetFmt)
+
+			return convert.Image(convert.ImageOptions{
+				Files:     files,
+				Target:    targetFmt,
+				Quality:   quality,
+				OutputDir: outputDir,
+				InPlace:   inPlace,
+				DryRun:    dryRun,
+			})
+		},
+	}
+	addTargetFlag(cmd, format.ImageTargets)
+
+	return cmd
 }
 
-// convertVideoCmd represents the convert video command.
-var convertVideoCmd = &cobra.Command{
-	Use:     "video",
-	Aliases: []string{"v"},
-	Short:   "Convert between video formats",
-	Long: `Convert video files between formats.
+func newVideoConvertCmd(use string, aliases []string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   "Convert between video formats",
+		Long: `Convert video files between containers using ffmpeg.
 
-Target formats: mp4, mkv, webm, mov, avi, flv`,
-	Example: `  uts convert video clip.mov --to mp4
-  uts convert video recording.mkv --to webm -q 20`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(derrors.CodeInvalidInput, "missing --to <format>")
-		}
+When the source codecs already fit the target container the streams are
+copied without re-encoding: instant and lossless. Pass -q to force a
+re-encode at that quality.
 
-		return convert.Video(convert.VideoOptions{
-			Files:      args,
-			Target:     strings.ToLower(targetFmt),
-			Quality:    quality,
-			QualitySet: cmd.Flags().Changed("quality"),
-			OutputDir:  outputDir,
-			InPlace:    inPlace,
-			DryRun:     dryRun,
-		})
-	},
+Target formats: ` + strings.Join(format.VideoTargets, ", "),
+		Example: `  uts video convert clip.mov --to mp4
+  uts video convert recording.mkv --to webm -q medium
+  uts video convert presentation.avi --to mkv -q 18
+  uts video convert ./clips --to mp4`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := requireTarget(format.VideoTargets)
+			if err != nil {
+				return err
+			}
+
+			files, err := inputs(args, format.VideoExts)
+			if err != nil {
+				return err
+			}
+
+			log.Debug("converting video files", "files", files, "target", targetFmt)
+
+			return convert.Video(convert.VideoOptions{
+				Files:      files,
+				Target:     targetFmt,
+				Quality:    quality,
+				QualitySet: cmd.Flags().Changed("quality"),
+				OutputDir:  outputDir,
+				InPlace:    inPlace,
+				DryRun:     dryRun,
+			})
+		},
+	}
+	addTargetFlag(cmd, format.VideoTargets)
+
+	return cmd
 }
 
-// convertAudioCmd represents the convert audio command.
-var convertAudioCmd = &cobra.Command{
-	Use:     "audio",
-	Aliases: []string{"a"},
-	Short:   "Convert between audio formats",
-	Long: `Convert audio files (or extract audio from video) between formats.
+func newAudioConvertCmd(use string, aliases []string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   "Convert between audio formats",
+		Long: `Convert audio files, or extract the audio track of video files, using ffmpeg.
 
-Target formats: mp3, aac, m4a, wav, flac, opus, ogg`,
-	Example: `  uts convert audio track.wav --to mp3 -q 96
-  uts convert audio video.mp4 --to mp3
-  uts convert audio song.flac --to m4a`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(derrors.CodeInvalidInput, "missing --to <format>")
-		}
+Target formats: ` + strings.Join(format.AudioTargets, ", "),
+		Example: `  uts audio convert track.wav --to mp3
+  uts audio convert video.mp4 --to mp3
+  uts audio convert song.flac --to m4a -q high
+  uts audio convert ./music --to opus -q 96`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := requireTarget(format.AudioTargets)
+			if err != nil {
+				return err
+			}
 
-		return convert.Audio(convert.AudioOptions{
-			Files:     args,
-			Target:    strings.ToLower(targetFmt),
-			Quality:   quality,
-			OutputDir: outputDir,
-			DryRun:    dryRun,
-		})
-	},
+			files, err := inputs(args, slices.Concat(format.AudioExts, format.VideoExts))
+			if err != nil {
+				return err
+			}
+
+			log.Debug("converting audio files", "files", files, "target", targetFmt)
+
+			return convert.Audio(convert.AudioOptions{
+				Files:     files,
+				Target:    targetFmt,
+				Quality:   quality,
+				OutputDir: outputDir,
+				InPlace:   inPlace,
+				DryRun:    dryRun,
+			})
+		},
+	}
+	addTargetFlag(cmd, format.AudioTargets)
+
+	return cmd
 }
 
-// convertPDFCmd represents the convert PDF command.
-var convertPDFCmd = &cobra.Command{
-	Use:     "pdf",
-	Aliases: []string{"p"},
-	Short:   "Convert PDF to/from images",
-	Long: `Convert PDF documents to images or combine images into PDF.
+func newPDFConvertCmd(use string, aliases []string) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     use,
+		Aliases: aliases,
+		Short:   "Convert between PDF and images",
+		Long: `Convert PDF documents to images or combine images into a PDF.
 
-Target formats: jpg, png (PDF→images), pdf (images→PDF)`,
-	Example: `  uts convert pdf report.pdf --to jpg
-  uts convert pdf '*.jpg' '*.png' --to pdf`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(derrors.CodeInvalidInput, "missing --to <format>")
-		}
+PDF → images: writes <basename>/page-*.<ext> next to the PDF (jpg or png)
+images → PDF: combines the images, in order, into a single PDF`,
+		Example: `  uts pdf convert report.pdf --to jpg
+  uts pdf convert slides.pdf --to png -q high
+  uts pdf convert page1.png page2.png --to pdf
+  uts pdf convert './scans/*.jpg' --to pdf`,
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := requireTarget(format.PDFTargets)
+			if err != nil {
+				return err
+			}
 
-		return convert.PDF(convert.PDFOptions{
-			Files:     args,
-			Target:    strings.ToLower(targetFmt),
-			Quality:   quality,
-			OutputDir: outputDir,
-			DryRun:    dryRun,
-		})
-	},
+			files, err := inputs(args, slices.Concat(format.PDFExts, format.ImageExts))
+			if err != nil {
+				return err
+			}
+
+			log.Debug("converting PDF files", "files", files, "target", targetFmt)
+
+			return convert.PDF(convert.PDFOptions{
+				Files:     files,
+				Target:    targetFmt,
+				Quality:   quality,
+				OutputDir: outputDir,
+				DryRun:    dryRun,
+			})
+		},
+	}
+	addTargetFlag(cmd, format.PDFTargets)
+
+	return cmd
 }
 
 func init() {
-	convertCmd.AddCommand(convertImageCmd)
-	convertCmd.AddCommand(convertVideoCmd)
-	convertCmd.AddCommand(convertAudioCmd)
-	convertCmd.AddCommand(convertPDFCmd)
+	convertCmd.AddCommand(newImageConvertCmd("image", []string{"img", "i"}))
+	convertCmd.AddCommand(newVideoConvertCmd("video", []string{"v"}))
+	convertCmd.AddCommand(newAudioConvertCmd("audio", []string{"a"}))
+	convertCmd.AddCommand(newPDFConvertCmd("pdf", []string{"p"}))
 }

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -7,8 +7,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"github.com/y3owk1n/uts/internal/compress"
-	"github.com/y3owk1n/uts/internal/convert"
-	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
 )
 
 // imageCmd represents the image command.
@@ -18,8 +17,8 @@ var imageCmd = &cobra.Command{
 	Short:   "Compress and convert image files",
 	Long: `Compress and convert images using format-specific tools.
 
-Input formats: png, jpg, jpeg, webp, gif, bmp, tiff, heic, heif, avif
-Output formats: jpg, png, webp, gif, bmp, tiff, avif`,
+Input formats: ` + strings.Join(format.ImageExts, ", ") + `
+Output formats: ` + strings.Join(format.ImageTargets, ", "),
 	Example: `  uts image compress screenshot.png -q medium
   uts image convert photo.heic --to jpg`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -34,55 +33,27 @@ var imageCompressCmd = &cobra.Command{
 	Short:   "Compress images using format-specific tools",
 	Long: `Compress images using the best available tool for each format.
 
-Tools by format: png (pngquant+optipng), jpg (jpegoptim),
-webp (cwebp), gif (gifsicle), bmp/tiff (ImageMagick),
-heic (heif-convert), avif (cavif/avifenc).
+Tools by format: png (pngquant+optipng), jpg (jpegoptim), webp (cwebp),
+gif (gifsicle), heic (heif-convert), bmp/tiff/avif (ImageMagick).
+ImageMagick is the fallback whenever a dedicated tool is missing.
 
-HEIC files are converted to JPEG.`,
+HEIC files are converted to JPEG. Results that are not smaller than the
+original are reported and, with -i, the original is kept.`,
 	Example: `  uts image compress screenshot.png -q medium
   uts image compress logo.jpg -q high -i
-  uts image compress '*.png' -r
-  uts image compress photo.webp -q 75 --dry-run -v`,
+  uts image compress ./photos -r
+  uts image compress '*.png' -q 75 --dry-run`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("compressing image files", "files", args)
-
-		return compress.Image(compress.ImageOptions{
-			Files:     args,
-			Quality:   quality,
-			OutputDir: outputDir,
-			InPlace:   inPlace,
-			DryRun:    dryRun,
-		})
-	},
-}
-
-// imageConvertCmd represents the image convert command.
-var imageConvertCmd = &cobra.Command{
-	Use:     "convert",
-	Aliases: []string{"x"},
-	Short:   "Convert between image formats",
-	Long: `Convert image files between formats using ImageMagick or sips.
-
-Target formats: jpg, png, webp, gif, bmp, tiff, avif`,
-	Example: `  uts image convert photo.heic --to jpg
-  uts image convert screenshot.png --to webp -q high
-  uts image convert photo.jpg --to avif -q 70
-  uts image convert '*.heic' --to jpg`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(
-				derrors.CodeInvalidInput,
-				"missing --to <format>. Examples: --to jpg, --to webp, --to png",
-			)
+		files, err := inputs(args, format.ImageExts)
+		if err != nil {
+			return err
 		}
 
-		log.Debug("converting image files", "files", args, "target", targetFmt)
+		log.Debug("compressing image files", "files", files)
 
-		return convert.Image(convert.ImageOptions{
-			Files:     args,
-			Target:    strings.ToLower(targetFmt),
+		return compress.Image(compress.ImageOptions{
+			Files:     files,
 			Quality:   quality,
 			OutputDir: outputDir,
 			InPlace:   inPlace,
@@ -93,5 +64,5 @@ Target formats: jpg, png, webp, gif, bmp, tiff, avif`,
 
 func init() {
 	imageCmd.AddCommand(imageCompressCmd)
-	imageCmd.AddCommand(imageConvertCmd)
+	imageCmd.AddCommand(newImageConvertCmd("convert", []string{"x"}))
 }

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -7,25 +7,24 @@ import (
 
 // infoCmd represents the info command.
 var infoCmd = &cobra.Command{
-	Use:   "info",
+	Use:   "info <input...>",
 	Short: "Show file info and suggestions",
 	Long: `Show file info and suggestions for compression/conversion.
 
-USAGE
-  uts info <input...> [options]
-
-DESCRIPTION
-  Displays file size, type, and suggests the best compress/convert
-  command for the detected format.
-
-EXAMPLES
-  uts info video.mp4
+Displays size, type and category, and suggests the best compress and
+convert command for the detected format.`,
+	Example: `  uts info video.mp4
   uts info '*.png'
-  uts info photo.heic`,
+  uts info ./downloads -r`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		files, err := inputs(args, nil)
+		if err != nil {
+			return err
+		}
+
 		info.Show(info.Options{
-			Files:   args,
+			Files:   files,
 			Version: Version,
 		})
 

--- a/cmd/pdf.go
+++ b/cmd/pdf.go
@@ -2,13 +2,10 @@
 package cmd
 
 import (
-	"strings"
-
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"github.com/y3owk1n/uts/internal/compress"
-	"github.com/y3owk1n/uts/internal/convert"
-	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
 )
 
 // pdfCmd represents the PDF command.
@@ -16,7 +13,7 @@ var pdfCmd = &cobra.Command{
 	Use:     "pdf",
 	Aliases: []string{"p"},
 	Short:   "Compress and convert PDF documents",
-	Long: `Compress and convert PDF documents using Ghostscript and ImageMagick.
+	Long: `Compress and convert PDF documents using Ghostscript, poppler and ImageMagick.
 
 Conversions: PDF ↔ jpg/png images.`,
 	Example: `  uts pdf compress thesis.pdf -q low
@@ -33,17 +30,22 @@ var pdfCompressCmd = &cobra.Command{
 	Short:   "Compress PDFs using Ghostscript",
 	Long: `Compress PDF documents using Ghostscript.
 
-Quality: high (300 DPI, /printer), medium (150 DPI, /ebook), low (72 DPI, /screen), or raw DPI.`,
+Quality: high (400 DPI, /printer), medium (300 DPI, /ebook), low (150 DPI, /screen), or raw DPI.`,
 	Example: `  uts pdf compress thesis.pdf -q low
   uts pdf compress report.pdf -q medium -o ./web/
   uts pdf compress slides.pdf -q 300 --dry-run
-  uts pdf compress '*.pdf' -r`,
+  uts pdf compress ./documents -r`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("compressing PDF files", "files", args)
+		files, err := inputs(args, format.PDFExts)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("compressing PDF files", "files", files)
 
 		return compress.PDF(compress.PDFOptions{
-			Files:     args,
+			Files:     files,
 			Quality:   quality,
 			OutputDir: outputDir,
 			InPlace:   inPlace,
@@ -52,41 +54,7 @@ Quality: high (300 DPI, /printer), medium (150 DPI, /ebook), low (72 DPI, /scree
 	},
 }
 
-// pdfConvertCmd represents the pdf convert command.
-var pdfConvertCmd = &cobra.Command{
-	Use:     "convert",
-	Aliases: []string{"x"},
-	Short:   "Convert between PDF and images",
-	Long: `Convert PDF documents to images or combine images into a PDF.
-
-PDF → images: creates <basename>/ directory with page-*.ext files (jpg/png)
-images → PDF: combines images into a single PDF`,
-	Example: `  uts pdf convert report.pdf --to jpg
-  uts pdf convert slides.pdf --to png -q high
-  uts pdf convert '*.jpg' '*.png' --to pdf
-  uts pdf convert images/*.png --to pdf`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(
-				derrors.CodeInvalidInput,
-				"missing --to <format>. Examples: --to jpg, --to png, --to pdf",
-			)
-		}
-
-		log.Debug("converting PDF files", "files", args, "target", targetFmt)
-
-		return convert.PDF(convert.PDFOptions{
-			Files:     args,
-			Target:    strings.ToLower(targetFmt),
-			Quality:   quality,
-			OutputDir: outputDir,
-			DryRun:    dryRun,
-		})
-	},
-}
-
 func init() {
 	pdfCmd.AddCommand(pdfCompressCmd)
-	pdfCmd.AddCommand(pdfConvertCmd)
+	pdfCmd.AddCommand(newPDFConvertCmd("convert", []string{"x"}))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,9 @@ import (
 
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/ui"
+	"github.com/y3owk1n/uts/internal/util"
 )
 
 var (
@@ -17,8 +20,8 @@ var (
 	algorithm string
 	targetFmt string
 
-	// Version is the current version of uts.
-	Version = "1.0.0"
+	// Version is the current version of uts, set at build time.
+	Version = "dev"
 	// GitCommit is the current commit hash of uts.
 	GitCommit = "unknown"
 	// BuildDate is the date of the current build.
@@ -34,11 +37,15 @@ var RootCmd = &cobra.Command{
 Compress, convert, and inspect any media file without remembering
 a dozen different command-line tools.
 
+Inputs may be files, directories, or quoted glob patterns. Directories are
+expanded to the files they contain (the whole tree with -r).
+
 Quality presets: low, medium, high, or a numeric value
 (CRF 0–51 for video, 1–100 for images, 96k–320k for audio, 72–300 DPI for PDF).
 
 Files are saved as <name>-small.<ext> by default. Use -i to replace in-place.`,
 	Example: `  uts image compress screenshot.png -q low
+  uts image compress ./photos -r
   uts video compress recording.mp4 -i
   uts convert image photo.heic --to jpg
   uts info video.mp4`,
@@ -57,10 +64,48 @@ func Execute() error {
 			log.SetLevel(log.DebugLevel)
 		}
 
+		if inPlace && outputDir != "" {
+			ui.Message.Warnf("--in-place is ignored when --output is set; originals are kept")
+
+			inPlace = false
+		}
+
 		return nil
 	}
 
 	return RootCmd.Execute()
+}
+
+// inputs expands CLI arguments into the files a command should process.
+// Globs are resolved, directories are listed (recursively with -r) and
+// filtered to the given extensions (nil keeps everything).
+func inputs(args []string, exts []string) ([]string, error) {
+	files := util.ExpandInputs(args, recursive, exts)
+	if len(files) == 0 {
+		return nil, derrors.New(derrors.CodeFileNotFound, "no input files matched")
+	}
+
+	log.Debug("resolved inputs", "count", len(files))
+
+	return files, nil
+}
+
+// requireTarget validates the --to flag for convert commands.
+func requireTarget(valid []string) error {
+	if targetFmt != "" {
+		return nil
+	}
+
+	return derrors.Newf(derrors.CodeInvalidInput, "missing --to <format>. Valid targets: %v", valid)
+}
+
+// addTargetFlag attaches the --to flag with shell completion for its values.
+func addTargetFlag(cmd *cobra.Command, valid []string) {
+	cmd.Flags().StringVar(&targetFmt, "to", "", "Target format: "+fmt.Sprint(valid))
+	_ = cmd.RegisterFlagCompletionFunc(
+		"to",
+		cobra.FixedCompletions(valid, cobra.ShellCompDirectiveNoFileComp),
+	)
 }
 
 func init() {
@@ -78,17 +123,13 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&outputDir, "output", "o", "",
 		"Output directory (default: same as input)")
 	RootCmd.PersistentFlags().BoolVarP(&inPlace, "in-place", "i", false,
-		"Replace original file with compressed version")
+		"Replace original file with the result")
 	RootCmd.PersistentFlags().BoolVarP(&dryRun, "dry-run", "n", false,
-		"Show what would be done without doing it")
+		"Show the commands that would run without running them")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
-		"Verbose output")
+		"Verbose output (logs every external command)")
 	RootCmd.PersistentFlags().BoolVarP(&recursive, "recursive", "r", false,
-		"Enable recursive glob patterns")
-	RootCmd.PersistentFlags().StringVar(&algorithm, "algorithm", "zip",
-		"Archive algorithm (gzip, zstd, xz, brotli, zip)")
-	RootCmd.PersistentFlags().StringVar(&targetFmt, "to", "",
-		"Target format for conversion")
+		"Recurse into directories and expand '**' glob patterns")
 
 	RootCmd.AddCommand(videoCmd)
 	RootCmd.AddCommand(imageCmd)

--- a/cmd/video.go
+++ b/cmd/video.go
@@ -7,8 +7,7 @@ import (
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
 	"github.com/y3owk1n/uts/internal/compress"
-	"github.com/y3owk1n/uts/internal/convert"
-	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/format"
 )
 
 // videoCmd represents the video command.
@@ -18,8 +17,8 @@ var videoCmd = &cobra.Command{
 	Short:   "Compress and convert video files",
 	Long: `Compress and convert video files using ffmpeg.
 
-Input formats: mp4, mov, mkv, avi, webm, m4v, flv, wmv
-Output formats: mp4, mov, mkv, webm, avi, flv`,
+Input formats: ` + strings.Join(format.VideoExts, ", ") + `
+Output formats: ` + strings.Join(format.VideoTargets, ", "),
 	Example: `  uts video compress screen-recording.mp4 -q low
   uts video convert clip.mov --to mp4`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -32,19 +31,25 @@ var videoCompressCmd = &cobra.Command{
 	Use:     "compress",
 	Aliases: []string{"c"},
 	Short:   "Compress video files using ffmpeg",
-	Long: `Compress video files using ffmpeg.
+	Long: `Compress video files using ffmpeg, keeping the container format.
 
+Codecs: mp4/mov/avi/flv use H.264, mkv uses H.265, webm uses VP9.
 Quality: high (crf=23, slow), medium (crf=28, medium), low (crf=32, fast), or raw 0-51.`,
 	Example: `  uts video compress screen-recording.mp4 -q low
   uts video compress vacation.mov -q high -i
-  uts video compress lecture.mkv -q 25 --dry-run -v
-  uts video compress '*.mp4' -r`,
+  uts video compress lecture.mkv -q 25 --dry-run
+  uts video compress ./recordings -r`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		log.Debug("compressing video files", "files", args)
+		files, err := inputs(args, format.VideoExts)
+		if err != nil {
+			return err
+		}
+
+		log.Debug("compressing video files", "files", files)
 
 		return compress.Video(compress.VideoOptions{
-			Files:     args,
+			Files:     files,
 			Quality:   quality,
 			OutputDir: outputDir,
 			InPlace:   inPlace,
@@ -53,42 +58,7 @@ Quality: high (crf=23, slow), medium (crf=28, medium), low (crf=32, fast), or ra
 	},
 }
 
-// videoConvertCmd represents the video convert command.
-var videoConvertCmd = &cobra.Command{
-	Use:     "convert",
-	Aliases: []string{"x"},
-	Short:   "Convert between video formats",
-	Long: `Convert video files between formats using ffmpeg.
-
-Target formats: mp4, mov, mkv, webm, avi, flv`,
-	Example: `  uts video convert clip.mov --to mp4
-  uts video convert recording.mkv --to webm -q medium
-  uts video convert presentation.avi --to mkv -q 18
-  uts video convert '*.mov' --to mp4`,
-	Args: cobra.MinimumNArgs(1),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		if targetFmt == "" {
-			return derrors.New(
-				derrors.CodeInvalidInput,
-				"missing --to <format>. Examples: --to mp4, --to mkv, --to webm",
-			)
-		}
-
-		log.Debug("converting video files", "files", args, "target", targetFmt)
-
-		return convert.Video(convert.VideoOptions{
-			Files:      args,
-			Target:     strings.ToLower(targetFmt),
-			Quality:    quality,
-			QualitySet: cmd.Flags().Changed("quality"),
-			OutputDir:  outputDir,
-			InPlace:    inPlace,
-			DryRun:     dryRun,
-		})
-	},
-}
-
 func init() {
 	videoCmd.AddCommand(videoCompressCmd)
-	videoCmd.AddCommand(videoConvertCmd)
+	videoCmd.AddCommand(newVideoConvertCmd("convert", []string{"x"}))
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -17,6 +17,12 @@ Where:
 - `<input...>` is one or more file paths, directories, or glob patterns.
 - `[options]` are flags modifying the default behavior.
 
+Inputs are expanded before anything runs:
+
+- Quoted glob patterns (`'*.png'`, `'**/*.jpg'` with `-r`) are resolved by `uts`, so they work the same in every shell.
+- A directory expands to the files it contains that the command supports (an image command ignores `.txt` files, for example). With `-r` the whole tree is walked.
+- Explicit file paths are used as given. A missing file is reported and counted as a failure.
+
 ---
 
 ## Categories & Actions
@@ -44,11 +50,18 @@ These options apply to commands across all categories:
 | `-i` | `--in-place`  | Replace the original source file with the processed version.                     | `false`            |
 | `-n` | `--dry-run`   | Print the compiled command without executing it.                                 | `false`            |
 | `-v` | `--verbose`   | Output raw debug logs and tool output commands.                                  | `false`            |
-| `-r` | `--recursive` | Evaluate recursive glob patterns (e.g., `**/*.png`).                             | `false`            |
-|      | `--algorithm` | Archive type algorithm selection (e.g., `gzip`, `zstd`, `xz`, `brotli`, `zip`).  | `zip`              |
-|      | `--to`        | Target format file extension when performing conversion.                         | _None_             |
+| `-r` | `--recursive` | Walk directories recursively and expand `**` glob patterns.                      | `false`            |
 | `-h` | `--help`      | Display syntax, actions, and options helper info.                                |                    |
 |      | `--version`   | Display version, commit hash, and build timestamp.                               |                    |
+
+When both `--output` and `--in-place` are given, `--in-place` is ignored with a warning so originals are never deleted.
+
+### Command Options
+
+| Flag          | Commands                | Description                                               | Default |
+| ------------- | ----------------------- | --------------------------------------------------------- | ------- |
+| `--to`        | every `convert` command | Target format. Tab completion lists the valid values.     | _None_  |
+| `--algorithm` | `archive compress`      | Archive algorithm: `zip`, `gzip`, `zstd`, `xz`, `brotli`. | `zip`   |
 
 ---
 
@@ -196,6 +209,7 @@ Inspects a media file's details (duration, codecs, resolution, file size) and di
 ```bash
 uts info video.mp4
 uts info screenshot.png
+uts info ./downloads -r
 ```
 
 ### Top-Level Shortcut
@@ -230,7 +244,7 @@ uts convert pdf report.pdf --to jpg
 | Code    | Meaning                                                                            |
 | ------- | ---------------------------------------------------------------------------------- |
 | **`0`** | Success. All input files processed cleanly.                                        |
-| **`1`** | Failure. One or more operations failed, or required dependency tools were missing. |
+| **`1`** | Failure. One or more files failed, no input matched, or a required tool was missing. |
 
 ---
 


### PR DESCRIPTION
This PR makes the CLI accept the inputs the README has always advertised and tidies the flag surface.

## What changed

- **Globs work.** `uts image compress '*.png'` used to print "File not found: *.png" because the glob resolver was never wired in. Quoted globs are now resolved by `uts`, and `'**/*.jpg'` with `-r` walks the tree.
- **Directories work.** `uts image compress ./photos` processes the supported files in that directory, and `-r` recurses. Files the command cannot handle (a `.DS_Store`, a `.txt`) are filtered out instead of producing "unsupported format" warnings.
- **Empty input is an error.** When nothing matches, the command exits 1 with `no input files matched`.
- **Flags live where they apply.** `--to` is a flag of the convert commands and `--algorithm` of `archive compress`, both with tab completion of valid values. They no longer appear in the help of unrelated commands. Existing invocations (`uts image convert x --to jpg`) are unchanged.
- **`-i` with `-o` is safe.** It is ignored with a warning, as the docs stated; before, the result was moved back over the original.
- `uts convert <category>` and `uts <category> convert` are built from the same code, help texts pull format lists from one place, and non-release builds report version `dev`.

Docs: CLI reference gains an "Inputs" section and a "Command Options" table; README examples and advanced-usage bullets updated.

## Why

Batch use is the main reason to wrap these tools, and the two batch features in the README did not work.

## How to test

```bash
just lint && just test-all
uts image compress '*.png' -n
uts image compress ./photos -r -n
uts image compress '*.xyz'; echo $?           # 1
uts image convert a.png --to jpg -o out -i    # warning, original kept
uts image compress --help | grep -- --to      # nothing
```