### PR TITLE
feat(info): show media details via ffprobe, extend doctor

### DIFF
--- a/cmd/info.go
+++ b/cmd/info.go
@@ -11,7 +11,8 @@ var infoCmd = &cobra.Command{
 	Short: "Show file info and suggestions",
 	Long: `Show file info and suggestions for compression/conversion.
 
-Displays size, type and category, and suggests the best compress and
+Displays size, type and category. For video, audio and images ffprobe adds
+duration, resolution, codecs and bit rate. Suggests the best compress and
 convert command for the detected format.`,
 	Example: `  uts info video.mp4
   uts info '*.png'
@@ -23,11 +24,9 @@ convert command for the detected format.`,
 			return err
 		}
 
-		info.Show(info.Options{
+		return info.Show(info.Options{
 			Files:   files,
 			Version: Version,
 		})
-
-		return nil
 	},
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -204,7 +204,7 @@ uts archive list project.tar.gz
 
 ### File Info
 
-Inspects a media file's details (duration, codecs, resolution, file size) and displays context-aware `uts` suggestions:
+Inspects a media file's details and displays context-aware `uts` suggestions. When `ffprobe` is installed, video, audio and image files also show duration, resolution, frame rate, codecs and bit rate:
 
 ```bash
 uts info video.mp4

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,6 +1,4 @@
 // Package doctor checks that external tools required by uts are available.
-//
-//nolint:goconst
 package doctor
 
 import (
@@ -8,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"runtime"
+	"slices"
 	"strings"
 
 	"charm.land/lipgloss/v2"
@@ -25,7 +24,9 @@ type tool struct {
 
 var baseTools = []tool{
 	{Name: "ffmpeg", Required: true, UsedBy: "video, audio"},
+	{Name: "ffprobe", Required: false, UsedBy: "info, video convert (stream copy)"},
 	{Name: "gs", Required: false, UsedBy: "pdf compress"},
+	{Name: "pdftoppm", Required: false, UsedBy: "pdf convert (PDF → images)"},
 	{Name: "pngquant", Required: false, UsedBy: "image compress (PNG)"},
 	{Name: "optipng", Required: false, UsedBy: "image compress (PNG)"},
 	{Name: "jpegoptim", Required: false, UsedBy: "image compress (JPEG)"},
@@ -39,6 +40,8 @@ var baseTools = []tool{
 	{Name: "zip", Required: false, UsedBy: "archive compress (zip)"},
 	{Name: "unzip", Required: false, UsedBy: "archive extract (zip)"},
 	{Name: "zstd", Required: false, UsedBy: "archive compress/extract (zstd)"},
+	{Name: "brotli", Required: false, UsedBy: "archive compress/extract (brotli)"},
+	{Name: "xz", Required: false, UsedBy: "archive compress/extract (xz)"},
 }
 
 // Run executes the doctor check and prints the results.
@@ -197,14 +200,21 @@ func brewList() string {
 		"magick":       "imagemagick",
 		"heif-convert": "libheif",
 		"avifenc":      "libavif",
-		"cavif":        "cavif",
+		"ffprobe":      "ffmpeg",
+		"pdftoppm":     "poppler",
 	}
 
-	for i, n := range names {
-		if mapped, ok := remap[n]; ok {
-			names[i] = mapped
+	var pkgs []string
+
+	for _, name := range names {
+		if mapped, ok := remap[name]; ok {
+			name = mapped
+		}
+
+		if !slices.Contains(pkgs, name) {
+			pkgs = append(pkgs, name)
 		}
 	}
 
-	return strings.Join(names, " ")
+	return strings.Join(pkgs, " ")
 }

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -1,6 +1,6 @@
 // Package info provides file information display functionality.
 //
-//nolint:goconst,mnd
+//nolint:mnd
 package info
 
 import (
@@ -8,8 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"charm.land/lipgloss/v2"
+	derrors "github.com/y3owk1n/uts/internal/core/errors"
+	"github.com/y3owk1n/uts/internal/ffmpeg"
+	"github.com/y3owk1n/uts/internal/format"
 	"github.com/y3owk1n/uts/internal/ui"
 	"github.com/y3owk1n/uts/internal/ui/style"
 	"github.com/y3owk1n/uts/internal/util"
@@ -21,16 +25,20 @@ type Options struct {
 	Version string
 }
 
-// Show displays information about the given files.
-func Show(opts Options) {
+// Show displays information about the given files. It returns an error when
+// any file could not be read so the CLI exits non-zero.
+func Show(opts Options) error {
 	_, _ = lipgloss.Fprint(os.Stdout, ui.Banner.Logo(opts.Version))
 
 	palette := ui.Style.Palette()
+	failed := 0
 
 	for _, file := range opts.Files {
 		fileInfo, err := os.Stat(file)
 		if err != nil {
 			ui.Message.Warnf("Cannot access: %s", file)
+
+			failed++
 
 			continue
 		}
@@ -38,57 +46,162 @@ func Show(opts Options) {
 		if fileInfo.IsDir() {
 			ui.Message.Warnf("Not a file: %s", file)
 
+			failed++
+
 			continue
 		}
 
-		ext := strings.ToLower(strings.TrimPrefix(filepath.Ext(file), "."))
-		size := util.FileSize(file)
-		base := filepath.Base(file)
+		ext := format.Ext(file)
+		cat := format.Classify(ext)
 
 		catColor := palette.Accent
-
-		category := classify(ext)
-		if category == "unknown" {
+		if cat == format.Unknown {
 			catColor = palette.Warning
 		}
 
-		body := fmt.Sprintf(
-			"  %s  %s\n  %s  %s\n  %s  %s\n  %s  %s\n",
-			keyStyle(palette, "Size:"),
-			ui.Message.Accent(util.HumanSize(size)),
-			keyStyle(palette, "Type:"),
-			ui.Message.Accent("."+ext),
-			keyStyle(palette, "Category:"),
-			lipgloss.NewStyle().Foreground(catColor).Render(category),
-			keyStyle(palette, "Tool:"),
-			ui.Message.Accent(toolHint(ext)),
-		)
+		rows := make([]row, 0, 8)
+		rows = append(rows, []row{
+			{"Size:", ui.Message.Accent(util.HumanSize(fileInfo.Size()))},
+			{"Type:", ui.Message.Accent("." + ext)},
+			{"Category:", lipgloss.NewStyle().Foreground(catColor).Render(string(cat))},
+			{"Tool:", ui.Message.Accent(toolHint(ext))},
+		}...)
+		rows = append(rows, mediaRows(file, cat)...)
 
-		suggestions := suggestActions(ext, file)
-		if suggestions != "" {
-			body += "\n" + lipgloss.NewStyle().
-				Foreground(palette.Subtle).
-				Render("Suggestions") +
-				"\n" + suggestions
+		var body strings.Builder
+		for _, r := range rows {
+			body.WriteString("  " + keyStyle(palette, r.key) + "  " + r.value + "\n")
 		}
 
-		_, _ = lipgloss.Fprint(os.Stdout, ui.Panel.Section(ui.Message.Highlight(base), body))
+		if suggestions := suggestActions(cat, file); suggestions != "" {
+			body.WriteString(
+				"\n" + lipgloss.NewStyle().
+					Foreground(palette.Subtle).
+					Render("Suggestions") +
+					"\n" + suggestions,
+			)
+		}
+
+		_, _ = lipgloss.Fprint(
+			os.Stdout,
+			ui.Panel.Section(ui.Message.Highlight(filepath.Base(file)), body.String()),
+		)
 	}
+
+	if failed > 0 {
+		return derrors.Newf(
+			derrors.CodeFileNotFound,
+			"%d of %d files could not be read",
+			failed,
+			len(opts.Files),
+		)
+	}
+
+	return nil
+}
+
+type row struct{ key, value string }
+
+// mediaRows adds ffprobe-derived details for video, audio and image files.
+// It is best effort: no ffprobe, or a file ffprobe cannot read, adds nothing.
+func mediaRows(file string, cat format.Category) []row {
+	if cat != format.Video && cat != format.Audio && cat != format.Image {
+		return nil
+	}
+
+	probe, err := ffmpeg.Probe(file)
+	if err != nil {
+		return nil
+	}
+
+	rows := make([]row, 0, 4)
+
+	if dur := probe.Duration(); dur > 0 && cat != format.Image {
+		rows = append(rows, row{"Duration:", ui.Message.Accent(formatDuration(dur))})
+	}
+
+	if video := probe.Video(); video != nil && video.Width > 0 {
+		res := fmt.Sprintf("%dx%d", video.Width, video.Height)
+		if cat == format.Video {
+			if fps := frameRate(video.FrameRate); fps != "" {
+				res += " @ " + fps + " fps"
+			}
+		}
+
+		rows = append(rows, row{"Resolution:", ui.Message.Accent(res)})
+	}
+
+	var codecs []string
+
+	if video := probe.Video(); video != nil {
+		codecs = append(codecs, video.Codec)
+	}
+
+	if audio := probe.Audio(); audio != nil {
+		desc := audio.Codec
+		if audio.SampleRate != "" {
+			desc += " " + audio.SampleRate + " Hz"
+		}
+
+		if audio.Channels > 0 {
+			desc += fmt.Sprintf(" %dch", audio.Channels)
+		}
+
+		codecs = append(codecs, desc)
+	}
+
+	if len(codecs) > 0 {
+		rows = append(rows, row{"Codec:", ui.Message.Accent(strings.Join(codecs, ", "))})
+	}
+
+	if rate := probe.BitRate(); rate > 0 && cat != format.Image {
+		rows = append(rows, row{"Bitrate:", ui.Message.Accent(fmt.Sprintf("%d kb/s", rate/1000))})
+	}
+
+	return rows
+}
+
+func formatDuration(seconds float64) string {
+	dur := time.Duration(seconds * float64(time.Second)).Round(time.Second)
+
+	hours := int(dur.Hours())
+	minutes := int(dur.Minutes()) % 60
+	secs := int(dur.Seconds()) % 60
+
+	if hours > 0 {
+		return fmt.Sprintf("%d:%02d:%02d", hours, minutes, secs)
+	}
+
+	return fmt.Sprintf("%d:%02d", minutes, secs)
+}
+
+// frameRate turns ffprobe's "30000/1001" into "29.97".
+func frameRate(ratio string) string {
+	num, den := 0.0, 0.0
+
+	_, err := fmt.Sscanf(ratio, "%f/%f", &num, &den)
+	if err != nil || den == 0 || num == 0 {
+		return ""
+	}
+
+	return strings.TrimSuffix(strings.TrimSuffix(fmt.Sprintf("%.2f", num/den), "0"), ".0")
 }
 
 func keyStyle(palette style.Palette, key string) string {
 	return lipgloss.NewStyle().
 		Foreground(palette.Muted).
-		Width(10).
+		Width(12).
 		Align(lipgloss.Right).
 		Render(key)
 }
 
 func toolHint(ext string) string {
-	switch {
-	case isVideo(ext):
-		return "ffmpeg (libx265)"
-	case isImage(ext):
+	switch format.Classify(ext) {
+	case format.Video:
+		vcodec, _ := format.VideoCodecs(ext)
+
+		return "ffmpeg (" + vcodec + ")"
+	case format.Image:
 		switch ext {
 		case "png":
 			return "pngquant + optipng"
@@ -99,96 +212,75 @@ func toolHint(ext string) string {
 		case "gif":
 			return "gifsicle"
 		case "heic", "heif":
-			return "ImageMagick (HEIC \u2192 JPEG)"
-		case "avif", "avifs":
-			return "cavif / libavif"
+			return "heif-convert (HEIC → JPEG)"
 		default:
 			return "ImageMagick"
 		}
-	case isAudio(ext):
-		return "ffmpeg (aac)"
-	case ext == "pdf":
+	case format.Audio:
+		codec, _ := format.AudioCompressTarget(ext)
+
+		return "ffmpeg (" + codec + ")"
+	case format.PDF:
 		return "ghostscript"
-	case isArchive(ext):
+	case format.Archive:
 		switch ext {
 		case "zip":
-			return "unzip"
-		case "gz", "tgz":
-			return "tar (gzip)"
+			return "zip / unzip"
 		case "zst", "zstd":
-			return "tar (zstd)"
-		case "xz", "txz":
-			return "tar (xz)"
-		case "bz2", "tbz2":
-			return "tar (bzip2)"
+			return "tar + zstd"
+		case "br":
+			return "tar + brotli"
 		default:
 			return "tar"
 		}
+	case format.Unknown:
+		return "—"
 	}
 
-	return "\u2014"
+	return "—"
 }
 
-func classify(ext string) string {
-	switch {
-	case isVideo(ext):
-		return "video"
-	case isImage(ext):
-		return "image"
-	case isAudio(ext):
-		return "audio"
-	case ext == "pdf":
-		return "pdf"
-	case isArchive(ext):
-		return "archive"
-	}
-
-	return "unknown"
-}
-
-func suggestActions(ext, file string) string {
+func suggestActions(cat format.Category, file string) string {
 	var lines []string
 
-	switch {
-	case isVideo(ext):
+	switch cat {
+	case format.Video:
 		lines = append(
 			lines,
 			detail(
 				"Compress",
 				fmt.Sprintf("uts video compress %q [-q low|medium|high|<0-51>]", file),
 			),
+			detail("Convert", fmt.Sprintf("uts video convert %q --to mp4", file)),
+			detail("Audio", fmt.Sprintf("uts audio convert %q --to mp3", file)),
 		)
-		lines = append(lines, detail("Convert", fmt.Sprintf("uts video convert %q --to mkv", file)))
-	case isImage(ext):
+	case format.Image:
 		lines = append(
 			lines,
 			detail(
 				"Compress",
 				fmt.Sprintf("uts image compress %q [-q low|medium|high|<1-100>]", file),
 			),
-		)
-		lines = append(
-			lines,
 			detail("Convert", fmt.Sprintf("uts image convert %q --to webp", file)),
 		)
-	case isAudio(ext):
+	case format.Audio:
 		lines = append(
 			lines,
 			detail(
 				"Compress",
 				fmt.Sprintf("uts audio compress %q [-q low|medium|high|<kbps>]", file),
 			),
+			detail("Convert", fmt.Sprintf("uts audio convert %q --to mp3", file)),
 		)
-		lines = append(lines, detail("Convert", fmt.Sprintf("uts audio convert %q --to mp3", file)))
-	case ext == "pdf":
-		lines = append(
-			lines,
+	case format.PDF:
+		lines = append(lines,
 			detail("Compress", fmt.Sprintf("uts pdf compress %q [-q low|medium|high|<dpi>]", file)),
-		)
-		lines = append(lines, detail("Convert", fmt.Sprintf("uts pdf convert %q --to jpg", file)))
-	case isArchive(ext):
-		lines = append(lines, detail("Extract", fmt.Sprintf("uts archive extract %q", file)))
-		lines = append(lines, detail("List", fmt.Sprintf("uts archive list %q", file)))
+			detail("Convert", fmt.Sprintf("uts pdf convert %q --to jpg", file)))
+	case format.Archive:
+		lines = append(lines,
+			detail("Extract", fmt.Sprintf("uts archive extract %q", file)),
+			detail("List", fmt.Sprintf("uts archive list %q", file)))
+	case format.Unknown:
 	}
 
 	return strings.Join(lines, "")
@@ -198,46 +290,10 @@ func detail(label, cmd string) string {
 	palette := ui.Style.Palette()
 	labelStyle := lipgloss.NewStyle().
 		Foreground(palette.Accent).
-		Width(10).
+		Width(12).
 		Align(lipgloss.Right).
 		Render
 	cmdStyle := lipgloss.NewStyle().Foreground(palette.Subtle).Render
 
 	return "    " + labelStyle(label+":") + "  " + cmdStyle(cmd) + "\n"
-}
-
-func isVideo(ext string) bool {
-	switch ext {
-	case "mp4", "mov", "mkv", "avi", "webm", "m4v", "flv", "wmv":
-		return true
-	}
-
-	return false
-}
-
-func isImage(ext string) bool {
-	switch ext {
-	case "png", "jpg", "jpeg", "webp", "gif", "bmp", "tiff", "tif", "heic", "heif", "avif", "avifs":
-		return true
-	}
-
-	return false
-}
-
-func isAudio(ext string) bool {
-	switch ext {
-	case "wav", "flac", "aac", "mp3", "m4a", "opus", "ogg", "wma":
-		return true
-	}
-
-	return false
-}
-
-func isArchive(ext string) bool {
-	switch ext {
-	case "zip", "tar", "gz", "tgz", "zst", "zstd", "xz", "txz", "bz2", "tbz2", "7z":
-		return true
-	}
-
-	return false
 }


### PR DESCRIPTION
This PR makes `uts info` show the media details the CLI reference already described, and teaches `uts doctor` about the tools the recent PRs started using.

## What changed

- **`uts info` reads metadata with ffprobe** when it is installed. Video files show duration, resolution, frame rate, codecs and bit rate. Audio files show duration, codec, sample rate, channels and bit rate. Images show dimensions and codec. Without ffprobe the output is the same as today.
- The tool hint names the codec `uts` will actually use for that file, and a video file gets an "extract audio" suggestion. Category detection comes from `internal/format` instead of a third copy of the extension lists.
- An unreadable file makes `uts info` exit 1.
- **`uts doctor`** checks `ffprobe`, `pdftoppm`, `brotli` and `xz`, maps them to their Homebrew packages (`ffmpeg`, `poppler`) and no longer repeats a package in the install hint.

Docs: CLI reference describes the ffprobe details.

## Why

The docs promised duration, codecs and resolution but `info` only printed size and extension. With remux and info both relying on ffprobe, doctor should tell users when it is missing.

## How to test

```bash
just lint && just test-all
uts info clip.mp4          # Duration, Resolution, Codec, Bitrate rows
uts info missing.mp4; echo $?   # 1
uts doctor                 # ffprobe, pdftoppm, brotli, xz listed
```