### PR TITLE
fix(cli): validate quality ranges, add --quiet, keep piped output clean

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,8 @@ You don't need to install all of them – `uts` will intelligently work with wha
 - **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in.
 - **Custom output directory**: Use `-o` (or `--output`) to specify where results are saved.
 - **Lossless video conversion**: `video convert` copies the streams into the new container whenever the codecs allow, so `mov → mp4` takes a second and loses nothing. Pass `-q` to force a re-encode.
-- **Scripting**: `uts` exits `1` when any file fails, and `-v` logs every external command it runs.
+- **Scripting**: `uts` exits `1` when any file fails, `--quiet` prints only warnings and errors, and `-v` logs every external command it runs. The banner is only shown on a terminal, so piped output stays clean.
+- **Shell completions**: `uts completion zsh|bash|fish` prints a completion script that also completes `--to` and `--algorithm` values. See the [Installation Guide](docs/INSTALLATION.md#shell-completions).
 
 For a complete reference, check out the [CLI Guide](docs/CLI.md).
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ var (
 	inPlace   bool
 	dryRun    bool
 	verbose   bool
+	quiet     bool
 	recursive bool
 	algorithm string
 	targetFmt string
@@ -62,7 +63,10 @@ func Execute() error {
 	RootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
 		if verbose {
 			log.SetLevel(log.DebugLevel)
+			log.SetReportTimestamp(false)
 		}
+
+		ui.SetQuiet(quiet && !verbose)
 
 		if inPlace && outputDir != "" {
 			ui.Message.Warnf("--in-place is ignored when --output is set; originals are kept")
@@ -128,6 +132,8 @@ func init() {
 		"Show the commands that would run without running them")
 	RootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false,
 		"Verbose output (logs every external command)")
+	RootCmd.PersistentFlags().BoolVar(&quiet, "quiet", false,
+		"Only print warnings and errors")
 	RootCmd.PersistentFlags().BoolVarP(&recursive, "recursive", "r", false,
 		"Recurse into directories and expand '**' glob patterns")
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -49,7 +49,8 @@ These options apply to commands across all categories:
 | `-o` | `--output`    | Destination directory.                                                           | Same as input file |
 | `-i` | `--in-place`  | Replace the original source file with the processed version.                     | `false`            |
 | `-n` | `--dry-run`   | Print the compiled command without executing it.                                 | `false`            |
-| `-v` | `--verbose`   | Output raw debug logs and tool output commands.                                  | `false`            |
+| `-v` | `--verbose`   | Log every external command that runs, plus debug output.                         | `false`            |
+|      | `--quiet`     | Print only warnings and errors. Spinners and progress are suppressed too.        | `false`            |
 | `-r` | `--recursive` | Walk directories recursively and expand `**` glob patterns.                      | `false`            |
 | `-h` | `--help`      | Display syntax, actions, and options helper info.                                |                    |
 |      | `--version`   | Display version, commit hash, and build timestamp.                               |                    |
@@ -74,7 +75,9 @@ The `-q, --quality` flag converts high-level presets (`low`, `medium`, `high`) t
 | **`high`**   | `23` (Slow, best quality)  | `192k`                   | `90%`                  | `400 DPI` (`/printer`)     |
 | **`medium`** | `28` (Balanced speed/size) | `128k`                   | `80%`                  | `300 DPI` (`/ebook`)       |
 | **`low`**    | `32` (Fast, smallest size) | `96k`                    | `60%`                  | `150 DPI` (`/screen`)      |
-| **`<num>`**  | Raw CRF (`0` to `51`)      | Raw bitrate (e.g. `256`) | Quality (`1` to `100`) | Raw DPI (e.g. `72`, `600`) |
+| **`<num>`**  | Raw CRF (`0` to `51`)      | Raw kbps (`32` to `512`) | Quality (`1` to `100`) | Raw DPI (`36` to `1200`)   |
+
+A number outside the range for its category is rejected before any tool runs, with a message naming the valid range.
 
 ---
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -16,6 +16,7 @@ This guide covers installation methods for `uts` and explains how to configure i
     - [Method 2: Nix Flake](#method-2-nix-flake)
     - [Method 3: Go Install](#method-3-go-install)
     - [Method 4: GitHub Release Binaries](#method-4-github-release-binaries)
+- [Shell Completions](#shell-completions)
 - [Verification](#verification)
 - [Troubleshooting](#troubleshooting)
 
@@ -224,6 +225,26 @@ export PATH="$HOME/go/bin:$PATH"
     ```bash
     chmod +x /usr/local/bin/uts
     ```
+
+---
+
+## Shell Completions
+
+`uts` can generate completion scripts for zsh, bash and fish. They complete subcommands, flags, and the values of `--to` and `--algorithm`.
+
+```bash
+# zsh (add to a directory on your $fpath, then restart the shell)
+uts completion zsh > "${fpath[1]}/_uts"
+
+# bash
+uts completion bash > /etc/bash_completion.d/uts        # Linux
+uts completion bash > "$(brew --prefix)/etc/bash_completion.d/uts"   # macOS with bash-completion
+
+# fish
+uts completion fish > ~/.config/fish/completions/uts.fish
+```
+
+Run `uts completion --help` for the full instructions per shell.
 
 ---
 

--- a/internal/archive/archive.go
+++ b/internal/archive/archive.go
@@ -160,7 +160,7 @@ func Extract(opts ExtractOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:   "Extracting",
 		Done:   "Extracted",
-		Noun:   "archives",
+		Noun:   "archive",
 		DryRun: opts.DryRun,
 		Code:   derrors.CodeArchiveFailed,
 	}, func(file string) (*job.Job, error) {

--- a/internal/compress/audio.go
+++ b/internal/compress/audio.go
@@ -39,7 +39,7 @@ func Audio(opts AudioOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Compressing",
 		Done:    "Compressed",
-		Noun:    "audio files",
+		Noun:    "audio file",
 		Compare: true,
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -28,7 +28,7 @@ type ImageOptions struct {
 
 // Image compresses image files using the best tool available per format.
 func Image(opts ImageOptions) error {
-	quality, err := util.PresetVal(opts.Quality, 60, 80, 90)
+	quality, err := util.ImageQuality(opts.Quality)
 	if err != nil {
 		return err
 	}
@@ -38,7 +38,7 @@ func Image(opts ImageOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Compressing",
 		Done:    "Compressed",
-		Noun:    "image files",
+		Noun:    "image file",
 		Compare: true,
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,

--- a/internal/compress/pdf.go
+++ b/internal/compress/pdf.go
@@ -48,7 +48,7 @@ func PDF(opts PDFOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Compressing",
 		Done:    "Compressed",
-		Noun:    "PDF files",
+		Noun:    "PDF file",
 		Compare: true,
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -43,7 +43,7 @@ func Video(opts VideoOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Compressing",
 		Done:    "Compressed",
-		Noun:    "video files",
+		Noun:    "video file",
 		Compare: true,
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,

--- a/internal/convert/audio.go
+++ b/internal/convert/audio.go
@@ -49,7 +49,7 @@ func Audio(opts AudioOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Converting",
 		Done:    "Converted",
-		Noun:    "audio files",
+		Noun:    "audio file",
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,
 		Code:    derrors.CodeConversionFailed,

--- a/internal/convert/image.go
+++ b/internal/convert/image.go
@@ -35,7 +35,7 @@ func Image(opts ImageOptions) error {
 		return unsupportedTarget(target, format.ImageTargets)
 	}
 
-	quality, err := util.PresetVal(opts.Quality, 60, 80, 90)
+	quality, err := util.ImageQuality(opts.Quality)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func Image(opts ImageOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Converting",
 		Done:    "Converted",
-		Noun:    "image files",
+		Noun:    "image file",
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,
 		Code:    derrors.CodeConversionFailed,

--- a/internal/convert/pdf.go
+++ b/internal/convert/pdf.go
@@ -71,7 +71,7 @@ func pdfToImages(opts PDFOptions, target string) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:   "Extracting",
 		Done:   "Extracted",
-		Noun:   "PDF files",
+		Noun:   "PDF file",
 		DryRun: opts.DryRun,
 		Code:   derrors.CodeConversionFailed,
 	}, func(file string) (*job.Job, error) {

--- a/internal/convert/video.go
+++ b/internal/convert/video.go
@@ -50,7 +50,7 @@ func Video(opts VideoOptions) error {
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Converting",
 		Done:    "Converted",
-		Noun:    "video files",
+		Noun:    "video file",
 		InPlace: opts.InPlace,
 		DryRun:  opts.DryRun,
 		Code:    derrors.CodeConversionFailed,

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -48,7 +48,7 @@ var baseTools = []tool{
 func Run(version string) {
 	palette := ui.Style.Palette()
 
-	_, _ = lipgloss.Fprint(os.Stdout, ui.Banner.Logo(version))
+	ui.PrintBanner(version)
 
 	missing := 0
 	found := 0

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -34,7 +34,8 @@ func Run(version string) {
 		tbl.Row(v.Section, v.Name, ui.Message.Accent(v.Value))
 	}
 
-	_, _ = lipgloss.Fprint(os.Stdout, ui.Banner.Logo(version))
+	ui.PrintBanner(version)
+
 	_, _ = lipgloss.Fprintln(os.Stdout)
 	_, _ = lipgloss.Fprint(os.Stdout, tbl.Render(palette))
 }

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -28,7 +28,7 @@ type Options struct {
 // Show displays information about the given files. It returns an error when
 // any file could not be read so the CLI exits non-zero.
 func Show(opts Options) error {
-	_, _ = lipgloss.Fprint(os.Stdout, ui.Banner.Logo(opts.Version))
+	ui.PrintBanner(opts.Version)
 
 	palette := ui.Style.Palette()
 	failed := 0

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -57,7 +57,8 @@ type Options struct {
 	Verb string
 	// Done is the past tense used in the summary, e.g. "Compressed".
 	Done string
-	// Noun names the inputs in the summary, e.g. "image files".
+	// Noun names one input in the summary, e.g. "image file"; it is
+	// pluralized as needed.
 	Noun string
 	// Compare reports the size delta and refuses to replace an original with
 	// a larger result.
@@ -289,14 +290,22 @@ func replaceInPlace(job *Job) {
 	}
 }
 
+func plural(count int, noun string) string {
+	if count == 1 {
+		return "1 " + noun
+	}
+
+	return fmt.Sprintf("%d %ss", count, noun)
+}
+
 func summarize(opts Options, done, failed, skipped int, saved int64) {
 	if opts.DryRun {
-		ui.Message.Infof("[dry-run] %d %s previewed, nothing written", done, opts.Noun)
+		ui.Message.Infof("[dry-run] %s previewed, nothing written", plural(done, opts.Noun))
 
 		return
 	}
 
-	msg := fmt.Sprintf("%s %d %s", opts.Done, done, opts.Noun)
+	msg := opts.Done + " " + plural(done, opts.Noun)
 
 	var extra []string
 	if skipped > 0 {

--- a/internal/ui/facade.go
+++ b/internal/ui/facade.go
@@ -3,6 +3,7 @@ package ui
 import (
 	"os"
 
+	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/term"
 	"github.com/y3owk1n/uts/internal/ui/banner"
 	"github.com/y3owk1n/uts/internal/ui/message"
@@ -57,4 +58,24 @@ func (tableAPI) New(headers ...string) *table.Table { return table.New(headers..
 // IsTTY reports whether the output is a terminal.
 func IsTTY() bool {
 	return term.IsTerminal(os.Stdout.Fd())
+}
+
+var quiet bool
+
+// SetQuiet silences informational output and spinners; warnings and errors
+// still print.
+func SetQuiet(on bool) {
+	quiet = on
+
+	Message.SetQuiet(on)
+}
+
+// PrintBanner prints the logo banner when stdout is a terminal and output is
+// not quiet, so piped output stays parseable.
+func PrintBanner(version string) {
+	if quiet || !IsTTY() {
+		return
+	}
+
+	_, _ = lipgloss.Fprint(os.Stdout, Banner.Logo(version))
 }

--- a/internal/ui/message/message.go
+++ b/internal/ui/message/message.go
@@ -41,6 +41,15 @@ type Printer struct {
 	icons   Icons
 	out     io.Writer
 	errOut  io.Writer
+	quiet   bool
+	// afterError is set by Errorf so the muted detail that follows it is
+	// shown even in quiet mode.
+	afterError bool
+}
+
+// SetQuiet suppresses everything except warnings and errors.
+func (pr *Printer) SetQuiet(quiet bool) {
+	pr.quiet = quiet
 }
 
 // New creates a new Printer.
@@ -72,11 +81,19 @@ func Default() *Printer {
 
 // Infof prints an info message.
 func (pr *Printer) Infof(format string, args ...any) {
+	if pr.quiet {
+		return
+	}
+
 	pr.line(pr.out, pr.icons.Info, fmt.Sprintf(format, args...), pr.palette.Accent)
 }
 
 // Successf prints a success message.
 func (pr *Printer) Successf(format string, args ...any) {
+	if pr.quiet {
+		return
+	}
+
 	pr.line(pr.out, pr.icons.Success, fmt.Sprintf(format, args...), pr.palette.Success)
 }
 
@@ -87,16 +104,25 @@ func (pr *Printer) Warnf(format string, args ...any) {
 
 // Errorf prints an error message.
 func (pr *Printer) Errorf(format string, args ...any) {
+	pr.afterError = true
 	pr.line(pr.errOut, pr.icons.Error, fmt.Sprintf(format, args...), pr.palette.Error)
 }
 
 // Stepf prints a step message.
 func (pr *Printer) Stepf(format string, args ...any) {
+	if pr.quiet {
+		return
+	}
+
 	pr.line(pr.out, pr.icons.Step, fmt.Sprintf(format, args...), pr.palette.Primary)
 }
 
 // Bulletf prints a bullet point.
 func (pr *Printer) Bulletf(format string, args ...any) {
+	if pr.quiet {
+		return
+	}
+
 	styled := lipgloss.NewStyle().
 		Foreground(pr.palette.Muted).
 		Render("  " + pr.icons.Bullet + " " + fmt.Sprintf(format, args...))
@@ -104,14 +130,24 @@ func (pr *Printer) Bulletf(format string, args ...any) {
 	lipgloss.Fprintln(pr.out, styled)
 }
 
-// Mutedf prints a muted message.
+// Mutedf prints a muted message. Muted lines that follow an error (tool
+// output) still print in quiet mode because they explain the failure.
 func (pr *Printer) Mutedf(format string, args ...any) {
+	if pr.quiet && !pr.afterError {
+		return
+	}
+
+	pr.afterError = false
 	//nolint:errcheck
 	lipgloss.Fprintln(pr.out, pr.types.Muted.Render(fmt.Sprintf(format, args...)))
 }
 
 // Pair prints a key-value pair.
 func (pr *Printer) Pair(key, value string) {
+	if pr.quiet {
+		return
+	}
+
 	styledKey := pr.types.Key.Render(key)
 	styledVal := pr.types.Code.Render(value)
 	//nolint:errcheck

--- a/internal/ui/spinner.go
+++ b/internal/ui/spinner.go
@@ -72,7 +72,7 @@ func (s *Spinner) SetSuffix(suffix string) {
 
 // Start starts the spinner animation.
 func (s *Spinner) Start() {
-	if !s.isTerminal {
+	if !s.isTerminal || quiet {
 		return
 	}
 

--- a/internal/util/quality.go
+++ b/internal/util/quality.go
@@ -7,6 +7,18 @@ import (
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
 )
 
+// Numeric quality ranges accepted per category.
+const (
+	ImageQualityMin = 1
+	ImageQualityMax = 100
+	VideoCRFMin     = 0
+	VideoCRFMax     = 51
+	AudioKbpsMin    = 32
+	AudioKbpsMax    = 512
+	PDFDPIMin       = 36
+	PDFDPIMax       = 1200
+)
+
 // PresetVal converts a quality preset name to its numeric value.
 func PresetVal(level string, low, med, high int) (int, error) {
 	if isNumeric(level) {
@@ -29,10 +41,25 @@ func PresetVal(level string, low, med, high int) (int, error) {
 	}
 }
 
+// ImageQuality converts a quality level to an image quality percentage.
+func ImageQuality(level string) (int, error) {
+	val, err := PresetVal(level, 60, 80, 90)
+	if err != nil {
+		return 0, err
+	}
+
+	return val, checkRange(val, ImageQualityMin, ImageQualityMax, "image quality")
+}
+
 // VideoQuality converts a quality level to CRF and bitrate values.
 func VideoQuality(level string) (int, string, error) {
 	if isNumeric(level) {
 		crf := parseInt(level)
+
+		err := checkRange(crf, VideoCRFMin, VideoCRFMax, "video CRF")
+		if err != nil {
+			return 0, "", err
+		}
 
 		var preset string
 		switch {
@@ -65,22 +92,25 @@ func VideoQuality(level string) (int, string, error) {
 
 // AudioBitrate converts a quality level to an audio bitrate.
 func AudioBitrate(level string) (string, error) {
-	if isNumeric(level) {
-		return level + "k", nil
-	}
-
-	v, err := PresetVal(level, 96, 128, 192)
+	kbps, err := PresetVal(level, 96, 128, 192)
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("%dk", v), nil
+	err = checkRange(kbps, AudioKbpsMin, AudioKbpsMax, "audio bitrate (kbps)")
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%dk", kbps), nil
 }
 
 // PDFDPI converts a quality level to PDF DPI.
 func PDFDPI(level string) (int, string, error) {
 	if isNumeric(level) {
-		return parseInt(level), "", nil
+		dpi := parseInt(level)
+
+		return dpi, "", checkRange(dpi, PDFDPIMin, PDFDPIMax, "PDF DPI")
 	}
 
 	switch level {
@@ -97,6 +127,21 @@ func PDFDPI(level string) (int, string, error) {
 			level,
 		)
 	}
+}
+
+func checkRange(val, low, high int, what string) error {
+	if val < low || val > high {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"%s must be between %d and %d, got %d",
+			what,
+			low,
+			high,
+			val,
+		)
+	}
+
+	return nil
 }
 
 func isNumeric(str string) bool {

--- a/internal/util/quality_test.go
+++ b/internal/util/quality_test.go
@@ -143,3 +143,46 @@ func TestPDFDPI(t *testing.T) {
 		}
 	}
 }
+
+// TestQualityRanges tests that out-of-range numeric values are rejected with
+// a clear error instead of being handed to the tool.
+func TestQualityRanges(t *testing.T) {
+	bad := []struct{ kind, level string }{
+		{"image", "0"},
+		{"image", "101"},
+		{"video", "52"},
+		{"audio", "20"},
+		{"audio", "9999"},
+		{"pdf", "10"},
+		{"pdf", "5000"},
+	}
+
+	for _, testCase := range bad {
+		var err error
+
+		switch testCase.kind {
+		case "image":
+			_, err = ImageQuality(testCase.level)
+		case "video":
+			_, _, err = VideoQuality(testCase.level)
+		case "audio":
+			_, err = AudioBitrate(testCase.level)
+		default:
+			_, _, err = PDFDPI(testCase.level)
+		}
+
+		if err == nil {
+			t.Errorf("%s quality %s: expected an out-of-range error", testCase.kind, testCase.level)
+		}
+	}
+
+	val, err := ImageQuality("100")
+	if err != nil || val != 100 {
+		t.Errorf("ImageQuality(100) = %d, %v; want 100, nil", val, err)
+	}
+
+	crf, _, err := VideoQuality("0")
+	if err != nil || crf != 0 {
+		t.Errorf("VideoQuality(0) = %d, %v; want 0, nil", crf, err)
+	}
+}


### PR DESCRIPTION
This PR is the quick-fix batch of the UX series: input validation, a quiet mode, and cleaner output for scripts.

## What changed

- **Numeric `-q` is validated.** `uts image compress x.png -q 500` used to fail inside pngquant with an opaque error. Values outside the category's range are now rejected before any tool runs: image 1-100, video CRF 0-51, audio 32-512 kbps, PDF 36-1200 DPI.
- **`--quiet`.** Prints only warnings and errors, and suppresses spinners. When a step fails, the tool output that explains it is still shown. Combined with `-v`, verbose wins.
- **Clean piped output.** The banner that `info`, `doctor` and `env` print is now only shown on a terminal.
- **Grammar.** Summaries say "Compressed 1 image file" instead of "1 image files".
- **`-v` logs** drop the timestamp prefix so they read like the rest of the output.

Docs: CLI reference lists `--quiet` and the numeric ranges; the installation guide gains a Shell Completions section (zsh, bash, fish) and the README points at it.

## Why

These were the rough edges left after the rewrite: a wrong number gave a confusing failure, and there was no way to run `uts` in a script without a wall of output.

## How to test

```bash
just lint && just test-all
uts image compress x.png -q 500      # "image quality must be between 1 and 100, got 500"
uts image compress x.png --quiet     # prints nothing on success
uts info x.png | head -3             # no banner
uts completion zsh | head -1
```