### PR TITLE
feat(info): add --json output and PDF page count

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ You don't need to install all of them – `uts` will intelligently work with wha
 - **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in.
 - **Custom output directory**: Use `-o` (or `--output`) to specify where results are saved.
 - **Lossless video conversion**: `video convert` copies the streams into the new container whenever the codecs allow, so `mov → mp4` takes a second and loses nothing. Pass `-q` to force a re-encode.
-- **Scripting**: `uts` exits `1` when any file fails, `--quiet` prints only warnings and errors, and `-v` logs every external command it runs. The banner is only shown on a terminal, so piped output stays clean.
+- **Scripting**: `uts` exits `1` when any file fails, `--quiet` prints only warnings and errors, `uts info --json` emits machine-readable details, and `-v` logs every external command it runs. The banner is only shown on a terminal, so piped output stays clean.
 - **Shell completions**: `uts completion zsh|bash|fish` prints a completion script that also completes `--to` and `--algorithm` values. See the [Installation Guide](docs/INSTALLATION.md#shell-completions).
 
 For a complete reference, check out the [CLI Guide](docs/CLI.md).

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -5,6 +5,8 @@ import (
 	"github.com/y3owk1n/uts/internal/info"
 )
 
+var infoJSON bool
+
 // infoCmd represents the info command.
 var infoCmd = &cobra.Command{
 	Use:   "info <input...>",
@@ -12,11 +14,14 @@ var infoCmd = &cobra.Command{
 	Long: `Show file info and suggestions for compression/conversion.
 
 Displays size, type and category. For video, audio and images ffprobe adds
-duration, resolution, codecs and bit rate. Suggests the best compress and
-convert command for the detected format.`,
+duration, resolution, codecs and bit rate; PDFs show their page count.
+Suggests the best compress and convert command for the detected format.
+
+--json prints one JSON array with the same details for scripting.`,
 	Example: `  uts info video.mp4
   uts info '*.png'
-  uts info ./downloads -r`,
+  uts info ./downloads -r
+  uts info clip.mp4 --json | jq '.[0].durationSeconds'`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		files, err := inputs(args, nil)
@@ -27,6 +32,11 @@ convert command for the detected format.`,
 		return info.Show(info.Options{
 			Files:   files,
 			Version: Version,
+			JSON:    infoJSON,
 		})
 	},
+}
+
+func init() {
+	infoCmd.Flags().BoolVar(&infoJSON, "json", false, "Print a JSON array instead of panels")
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -207,13 +207,21 @@ uts archive list project.tar.gz
 
 ### File Info
 
-Inspects a media file's details and displays context-aware `uts` suggestions. When `ffprobe` is installed, video, audio and image files also show duration, resolution, frame rate, codecs and bit rate:
+Inspects a media file's details and displays context-aware `uts` suggestions. When `ffprobe` is installed, video, audio and image files also show duration, resolution, frame rate, codecs and bit rate. PDFs show their page count via `pdfinfo` or Ghostscript:
 
 ```bash
 uts info video.mp4
 uts info screenshot.png
 uts info ./downloads -r
 ```
+
+`--json` prints one array with the same details, for scripts:
+
+```bash
+uts info clip.mp4 --json | jq '.[0] | {durationSeconds, width, height, videoCodec}'
+```
+
+Fields: `path`, `name`, `sizeBytes`, `size`, `ext`, `category`, `tool`, and when available `durationSeconds`, `duration`, `width`, `height`, `frameRate`, `videoCodec`, `audioCodec`, `sampleRate`, `channels`, `bitRateKbps`, `pages`. An unreadable file has an `error` field and makes the command exit `1`.
 
 ### Top-Level Shortcut
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -27,6 +27,7 @@ var baseTools = []tool{
 	{Name: "ffprobe", Required: false, UsedBy: "info, video convert (stream copy)"},
 	{Name: "gs", Required: false, UsedBy: "pdf compress"},
 	{Name: "pdftoppm", Required: false, UsedBy: "pdf convert (PDF → images)"},
+	{Name: "pdfinfo", Required: false, UsedBy: "info (PDF page count)"},
 	{Name: "pngquant", Required: false, UsedBy: "image compress (PNG)"},
 	{Name: "optipng", Required: false, UsedBy: "image compress (PNG)"},
 	{Name: "jpegoptim", Required: false, UsedBy: "image compress (JPEG)"},
@@ -202,6 +203,7 @@ func brewList() string {
 		"avifenc":      "libavif",
 		"ffprobe":      "ffmpeg",
 		"pdftoppm":     "poppler",
+		"pdfinfo":      "poppler",
 	}
 
 	var pkgs []string

--- a/internal/info/info.go
+++ b/internal/info/info.go
@@ -4,9 +4,11 @@
 package info
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,69 +25,65 @@ import (
 type Options struct {
 	Files   []string
 	Version string
+	// JSON prints one machine-readable array instead of styled panels.
+	JSON bool
+}
+
+// Report is everything uts knows about one file. It is the JSON schema of
+// "uts info --json"; fields that do not apply to a file are omitted.
+type Report struct {
+	Path      string          `json:"path"`
+	Name      string          `json:"name"`
+	SizeBytes int64           `json:"sizeBytes"`
+	Size      string          `json:"size"`
+	Ext       string          `json:"ext"`
+	Category  format.Category `json:"category"`
+	Tool      string          `json:"tool"`
+
+	DurationSeconds float64 `json:"durationSeconds,omitempty"`
+	Duration        string  `json:"duration,omitempty"`
+	Width           int     `json:"width,omitempty"`
+	Height          int     `json:"height,omitempty"`
+	FrameRate       string  `json:"frameRate,omitempty"`
+	VideoCodec      string  `json:"videoCodec,omitempty"`
+	AudioCodec      string  `json:"audioCodec,omitempty"`
+	SampleRate      string  `json:"sampleRate,omitempty"`
+	Channels        int     `json:"channels,omitempty"`
+	BitRateKbps     int64   `json:"bitRateKbps,omitempty"`
+	Pages           int     `json:"pages,omitempty"`
+
+	Error string `json:"error,omitempty"`
 }
 
 // Show displays information about the given files. It returns an error when
 // any file could not be read so the CLI exits non-zero.
 func Show(opts Options) error {
-	ui.PrintBanner(opts.Version)
-
-	palette := ui.Style.Palette()
+	reports := make([]Report, 0, len(opts.Files))
 	failed := 0
 
 	for _, file := range opts.Files {
-		fileInfo, err := os.Stat(file)
+		report := Collect(file)
+		if report.Error != "" {
+			failed++
+		}
+
+		reports = append(reports, report)
+	}
+
+	if opts.JSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+
+		err := enc.Encode(reports)
 		if err != nil {
-			ui.Message.Warnf("Cannot access: %s", file)
-
-			failed++
-
-			continue
+			return derrors.Wrap(err, derrors.CodeInvalidInput, "encode JSON")
 		}
+	} else {
+		ui.PrintBanner(opts.Version)
 
-		if fileInfo.IsDir() {
-			ui.Message.Warnf("Not a file: %s", file)
-
-			failed++
-
-			continue
+		for _, report := range reports {
+			render(report)
 		}
-
-		ext := format.Ext(file)
-		cat := format.Classify(ext)
-
-		catColor := palette.Accent
-		if cat == format.Unknown {
-			catColor = palette.Warning
-		}
-
-		rows := make([]row, 0, 8)
-		rows = append(rows, []row{
-			{"Size:", ui.Message.Accent(util.HumanSize(fileInfo.Size()))},
-			{"Type:", ui.Message.Accent("." + ext)},
-			{"Category:", lipgloss.NewStyle().Foreground(catColor).Render(string(cat))},
-			{"Tool:", ui.Message.Accent(toolHint(ext))},
-		}...)
-		rows = append(rows, mediaRows(file, cat)...)
-
-		var body strings.Builder
-		for _, r := range rows {
-			body.WriteString("  " + keyStyle(palette, r.key) + "  " + r.value + "\n")
-		}
-
-		if suggestions := suggestActions(cat, file); suggestions != "" {
-			body.WriteString(
-				"\n" + lipgloss.NewStyle().
-					Foreground(palette.Subtle).
-					Render("Suggestions") +
-					"\n" + suggestions,
-			)
-		}
-
-		_, _ = lipgloss.Fprint(
-			os.Stdout,
-			ui.Panel.Section(ui.Message.Highlight(filepath.Base(file)), body.String()),
-		)
 	}
 
 	if failed > 0 {
@@ -100,32 +98,134 @@ func Show(opts Options) error {
 	return nil
 }
 
-type row struct{ key, value string }
+// Collect gathers the report for one file. Media details come from ffprobe
+// and PDF page counts from pdfinfo or Ghostscript; both are best effort.
+func Collect(file string) Report {
+	report := Report{Path: file, Name: filepath.Base(file)}
 
-// mediaRows adds ffprobe-derived details for video, audio and image files.
-// It is best effort: no ffprobe, or a file ffprobe cannot read, adds nothing.
-func mediaRows(file string, cat format.Category) []row {
-	if cat != format.Video && cat != format.Audio && cat != format.Image {
-		return nil
+	fileInfo, err := os.Stat(file)
+	if err != nil {
+		report.Error = "cannot access"
+
+		return report
 	}
 
+	if fileInfo.IsDir() {
+		report.Error = "not a file"
+
+		return report
+	}
+
+	report.Ext = format.Ext(file)
+	report.Category = format.Classify(report.Ext)
+	report.Tool = toolHint(report.Ext)
+	report.SizeBytes = fileInfo.Size()
+	report.Size = util.HumanSize(fileInfo.Size())
+
+	switch report.Category {
+	case format.Video, format.Audio, format.Image:
+		probeInto(&report, file)
+	case format.PDF:
+		report.Pages = pdfPages(file)
+	case format.Archive, format.Unknown:
+	}
+
+	return report
+}
+
+func probeInto(report *Report, file string) {
 	probe, err := ffmpeg.Probe(file)
 	if err != nil {
-		return nil
+		return
 	}
 
-	rows := make([]row, 0, 4)
-
-	if dur := probe.Duration(); dur > 0 && cat != format.Image {
-		rows = append(rows, row{"Duration:", ui.Message.Accent(formatDuration(dur))})
+	if dur := probe.Duration(); dur > 0 && report.Category != format.Image {
+		report.DurationSeconds = dur
+		report.Duration = formatDuration(dur)
 	}
 
-	if video := probe.Video(); video != nil && video.Width > 0 {
-		res := fmt.Sprintf("%dx%d", video.Width, video.Height)
-		if cat == format.Video {
-			if fps := frameRate(video.FrameRate); fps != "" {
-				res += " @ " + fps + " fps"
-			}
+	if video := probe.Video(); video != nil {
+		report.VideoCodec = video.Codec
+		report.Width = video.Width
+		report.Height = video.Height
+
+		if report.Category == format.Video {
+			report.FrameRate = frameRate(video.FrameRate)
+		}
+	}
+
+	if audio := probe.Audio(); audio != nil {
+		report.AudioCodec = audio.Codec
+		report.SampleRate = audio.SampleRate
+		report.Channels = audio.Channels
+	}
+
+	if rate := probe.BitRate(); rate > 0 && report.Category != format.Image {
+		report.BitRateKbps = rate / 1000
+	}
+}
+
+type row struct{ key, value string }
+
+func render(report Report) {
+	if report.Error != "" {
+		switch report.Error {
+		case "not a file":
+			ui.Message.Warnf("Not a file: %s", report.Path)
+		default:
+			ui.Message.Warnf("Cannot access: %s", report.Path)
+		}
+
+		return
+	}
+
+	palette := ui.Style.Palette()
+
+	catColor := palette.Accent
+	if report.Category == format.Unknown {
+		catColor = palette.Warning
+	}
+
+	rows := make([]row, 0, 9)
+	rows = append(rows,
+		row{"Size:", ui.Message.Accent(report.Size)},
+		row{"Type:", ui.Message.Accent("." + report.Ext)},
+		row{"Category:", lipgloss.NewStyle().Foreground(catColor).Render(string(report.Category))},
+		row{"Tool:", ui.Message.Accent(report.Tool)},
+	)
+	rows = append(rows, detailRows(report)...)
+
+	var body strings.Builder
+	for _, r := range rows {
+		body.WriteString("  " + keyStyle(palette, r.key) + "  " + r.value + "\n")
+	}
+
+	if suggestions := suggestActions(report.Category, report.Path); suggestions != "" {
+		body.WriteString(
+			"\n" + lipgloss.NewStyle().
+				Foreground(palette.Subtle).
+				Render("Suggestions") +
+				"\n" + suggestions,
+		)
+	}
+
+	_, _ = lipgloss.Fprint(
+		os.Stdout,
+		ui.Panel.Section(ui.Message.Highlight(report.Name), body.String()),
+	)
+}
+
+func detailRows(report Report) []row {
+	rows := make([]row, 0, 5)
+
+	if report.Duration != "" {
+		rows = append(rows, row{"Duration:", ui.Message.Accent(report.Duration)})
+	}
+
+	if report.Width > 0 {
+		res := fmt.Sprintf("%dx%d", report.Width, report.Height)
+		if report.FrameRate != "" {
+			res += " @ " + report.FrameRate + " fps"
 		}
 
 		rows = append(rows, row{"Resolution:", ui.Message.Accent(res)})
@@ -133,18 +233,18 @@ func mediaRows(file string, cat format.Category) []row {
 
 	var codecs []string
 
-	if video := probe.Video(); video != nil {
-		codecs = append(codecs, video.Codec)
+	if report.VideoCodec != "" {
+		codecs = append(codecs, report.VideoCodec)
 	}
 
-	if audio := probe.Audio(); audio != nil {
-		desc := audio.Codec
-		if audio.SampleRate != "" {
-			desc += " " + audio.SampleRate + " Hz"
+	if report.AudioCodec != "" {
+		desc := report.AudioCodec
+		if report.SampleRate != "" {
+			desc += " " + report.SampleRate + " Hz"
 		}
 
-		if audio.Channels > 0 {
-			desc += fmt.Sprintf(" %dch", audio.Channels)
+		if report.Channels > 0 {
+			desc += fmt.Sprintf(" %dch", report.Channels)
 		}
 
 		codecs = append(codecs, desc)
@@ -154,8 +254,15 @@ func mediaRows(file string, cat format.Category) []row {
 		rows = append(rows, row{"Codec:", ui.Message.Accent(strings.Join(codecs, ", "))})
 	}
 
-	if rate := probe.BitRate(); rate > 0 && cat != format.Image {
-		rows = append(rows, row{"Bitrate:", ui.Message.Accent(fmt.Sprintf("%d kb/s", rate/1000))})
+	if report.BitRateKbps > 0 {
+		rows = append(
+			rows,
+			row{"Bitrate:", ui.Message.Accent(fmt.Sprintf("%d kb/s", report.BitRateKbps))},
+		)
+	}
+
+	if report.Pages > 0 {
+		rows = append(rows, row{"Pages:", ui.Message.Accent(strconv.Itoa(report.Pages))})
 	}
 
 	return rows

--- a/internal/info/pdf.go
+++ b/internal/info/pdf.go
@@ -1,0 +1,47 @@
+package info
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/y3owk1n/uts/internal/util"
+)
+
+// pdfPages returns the page count of a PDF using pdfinfo (poppler) or, when
+// that is missing, Ghostscript. It returns 0 when neither tool is available
+// or the file cannot be read.
+func pdfPages(file string) int {
+	if util.HasTool("pdfinfo") {
+		out, err := exec.CommandContext(context.Background(), "pdfinfo", file).Output()
+		if err == nil {
+			for line := range strings.SplitSeq(string(out), "\n") {
+				if after, ok := strings.CutPrefix(line, "Pages:"); ok {
+					pages, _ := strconv.Atoi(strings.TrimSpace(after))
+
+					return pages
+				}
+			}
+		}
+	}
+
+	if util.HasTool("gs") {
+		// PostScript string literal: escape backslashes and parentheses.
+		escaped := strings.NewReplacer(`\`, `\\`, `(`, `\(`, `)`, `\)`).Replace(file)
+
+		out, err := exec.CommandContext(context.Background(), "gs",
+			"-q", "-dNODISPLAY", "-dNOSAFER",
+			"-c", "("+escaped+") (r) file runpdfbegin pdfpagecount = quit").Output()
+		if err == nil {
+			lines := strings.Fields(string(out))
+			if len(lines) > 0 {
+				pages, _ := strconv.Atoi(lines[len(lines)-1])
+
+				return pages
+			}
+		}
+	}
+
+	return 0
+}


### PR DESCRIPTION
This PR makes `uts info` usable from scripts and adds the one detail PDFs were missing.

## What changed

- **`uts info --json`** prints a JSON array with the same details the panel shows: `path`, `name`, `sizeBytes`, `size`, `ext`, `category`, `tool`, and when available `durationSeconds`, `duration`, `width`, `height`, `frameRate`, `videoCodec`, `audioCodec`, `sampleRate`, `channels`, `bitRateKbps`, `pages`. Fields that do not apply are omitted. An unreadable file has an `error` field and the command still exits 1. No banner is printed in JSON mode.
- **PDF page count.** `uts info report.pdf` shows a Pages row, read with `pdfinfo` when poppler is installed and with Ghostscript otherwise. `uts doctor` lists `pdfinfo`.
- Internally, each file becomes an `info.Report` that both the panel renderer and the JSON encoder consume, so the two outputs cannot drift.

Docs: CLI reference documents `--json` and its fields; README mentions it under scripting.

## Why

`info` was the one command whose output could only be read by a human. A stable JSON shape lets it feed other tools, and page count is the first thing people want to know about a PDF.

## How to test

```bash
just lint && just test-all
uts info clip.mp4 --json | jq '.[0] | {durationSeconds, width, height, videoCodec}'
uts info report.pdf               # Pages row
uts info missing.mp4 --json; echo $?   # error field, exit 1
```