### PR TITLE
feat(ffmpeg): show percentage and time remaining during encodes

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -85,7 +85,7 @@ A number outside the range for its category is rejected before any tool runs, wi
 
 ### Video Commands
 
-Compression uses `ffmpeg` and keeps the input container: mp4/mov/avi/flv are encoded with H.264, mkv with H.265, and webm with VP9 (constant quality mode).
+Compression uses `ffmpeg` and keeps the input container: mp4/mov/avi/flv are encoded with H.264, mkv with H.265, and webm with VP9 (constant quality mode). While a file encodes, the spinner shows the percentage done and the time remaining (video and audio, when `ffprobe` is available).
 
 ```bash
 # Compress using low quality preset (smaller file)

--- a/internal/compress/audio.go
+++ b/internal/compress/audio.go
@@ -60,7 +60,7 @@ func Audio(opts AudioOptions) error {
 		return &job.Job{
 			Input:  file,
 			Output: out,
-			Steps: []job.Step{job.Exec("ffmpeg",
+			Steps: []job.Step{ffmpeg.Step(file,
 				"-i", file, "-vn", "-c:a", codec, "-b:a", bitrate, "-y", out)},
 			Note: fmt.Sprintf("%s %s → .%s", codec, bitrate, outExt),
 		}, nil

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -65,7 +65,7 @@ func Video(opts VideoOptions) error {
 			Input:  file,
 			Output: out,
 			Steps: []job.Step{
-				job.Exec("ffmpeg", ffmpeg.EncodeArgs(file, out, ext, crf, preset)...),
+				ffmpeg.Step(file, ffmpeg.EncodeArgs(file, out, ext, crf, preset)...),
 			},
 			Note: fmt.Sprintf("%s/%s crf=%d", vcodec, acodec, crf),
 		}, nil

--- a/internal/convert/audio.go
+++ b/internal/convert/audio.go
@@ -79,7 +79,7 @@ func Audio(opts AudioOptions) error {
 		return &job.Job{
 			Input:  file,
 			Output: out,
-			Steps:  []job.Step{job.Exec("ffmpeg", args...)},
+			Steps:  []job.Step{ffmpeg.Step(file, args...)},
 			Note:   fmt.Sprintf(".%s → .%s via %s", ext, outExt, codec),
 		}, nil
 	})

--- a/internal/convert/video.go
+++ b/internal/convert/video.go
@@ -76,7 +76,7 @@ func Video(opts VideoOptions) error {
 				return &job.Job{
 					Input:  file,
 					Output: out,
-					Steps:  []job.Step{job.Exec("ffmpeg", ffmpeg.RemuxArgs(file, out, target)...)},
+					Steps:  []job.Step{ffmpeg.Step(file, ffmpeg.RemuxArgs(file, out, target)...)},
 					Note:   "stream copy, no re-encode (pass -q to force re-encoding)",
 				}, nil
 			}
@@ -86,7 +86,7 @@ func Video(opts VideoOptions) error {
 			Input:  file,
 			Output: out,
 			Steps: []job.Step{
-				job.Exec("ffmpeg", ffmpeg.EncodeArgs(file, out, target, crf, preset)...),
+				ffmpeg.Step(file, ffmpeg.EncodeArgs(file, out, target, crf, preset)...),
 			},
 			Note: fmt.Sprintf("%s/%s crf=%d preset=%s", vcodec, acodec, crf, preset),
 		}, nil

--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -14,8 +14,52 @@ import (
 
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
 	"github.com/y3owk1n/uts/internal/format"
+	"github.com/y3owk1n/uts/internal/job"
 	"github.com/y3owk1n/uts/internal/util"
 )
+
+const microsPerSecond = 1_000_000
+
+// Step builds an ffmpeg job step that reports progress. The input is probed
+// for its duration so the runner can show a percentage and time remaining;
+// without ffprobe the step still runs, just without the numbers.
+func Step(input string, args ...string) job.Step {
+	full := append([]string{"-nostats", "-loglevel", "error", "-progress", "pipe:1"}, args...)
+	step := job.Exec("ffmpeg", full...)
+	step.Progress = &job.Progress{Total: DurationOf(input), Parse: ParseProgress}
+
+	return step
+}
+
+// DurationOf returns the media duration in seconds, or 0 when unknown.
+func DurationOf(file string) float64 {
+	info, err := Probe(file)
+	if err != nil {
+		return 0
+	}
+
+	return info.Duration()
+}
+
+// ParseProgress reads one line of "ffmpeg -progress" output and returns the
+// seconds of output written so far.
+func ParseProgress(line string) (float64, bool) {
+	value, ok := strings.CutPrefix(line, "out_time_us=")
+	if !ok {
+		// Older ffmpeg only prints out_time_ms, which is also microseconds.
+		value, ok = strings.CutPrefix(line, "out_time_ms=")
+		if !ok {
+			return 0, false
+		}
+	}
+
+	micros, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
+	if err != nil || micros < 0 {
+		return 0, false
+	}
+
+	return float64(micros) / microsPerSecond, true
+}
 
 // ErrNoProbe is returned when ffprobe is not installed.
 var ErrNoProbe = errors.New("ffprobe not found")

--- a/internal/ffmpeg/ffmpeg_test.go
+++ b/internal/ffmpeg/ffmpeg_test.go
@@ -69,6 +69,44 @@ func TestRemuxArgs(t *testing.T) {
 	}
 }
 
+func TestParseProgress(t *testing.T) {
+	tests := []struct {
+		line string
+		want float64
+		ok   bool
+	}{
+		{"out_time_us=1500000", 1.5, true},
+		{"out_time_ms=2000000", 2, true},
+		{"out_time_us=N/A", 0, false},
+		{"frame=12", 0, false},
+		{"progress=end", 0, false},
+	}
+	for _, testCase := range tests {
+		got, parsed := ffmpeg.ParseProgress(testCase.line)
+		if parsed != testCase.ok || got != testCase.want {
+			t.Errorf(
+				"ParseProgress(%q) = (%v, %v); want (%v, %v)",
+				testCase.line,
+				got,
+				parsed,
+				testCase.want,
+				testCase.ok,
+			)
+		}
+	}
+}
+
+func TestStepCarriesProgress(t *testing.T) {
+	step := ffmpeg.Step("missing.mp4", "-i", "missing.mp4", "-y", "out.mp4")
+	if step.Progress == nil || step.Progress.Parse == nil {
+		t.Fatal("Step should attach a progress parser")
+	}
+
+	if !slices.Contains(step.Cmd.Args, "-progress") {
+		t.Errorf("Step should request -progress output: %v", step.Cmd.Args)
+	}
+}
+
 func TestCanRemux(t *testing.T) {
 	info := &ffmpeg.Info{Streams: []ffmpeg.Stream{
 		{Type: "video", Codec: "h264"},

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -4,12 +4,15 @@
 package job
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"strings"
+	"time"
 
 	"charm.land/log/v2"
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
@@ -18,7 +21,14 @@ import (
 	"github.com/y3owk1n/uts/internal/util"
 )
 
-const tailLines = 12
+const (
+	tailLines      = 12
+	percent        = 100
+	secondsPerMin  = 60
+	secondsPerHour = 3600
+	// minProgressForETA avoids wild estimates in the first moments.
+	minProgressForETA = 0.02
+)
 
 var errNoOutput = errors.New("no output produced")
 
@@ -28,6 +38,18 @@ type Step struct {
 	Cmd  *exec.Cmd
 	Desc string
 	Fn   func() error
+	// Progress, when set, makes the runner read the command's stdout line
+	// by line and report completion as it goes.
+	Progress *Progress
+}
+
+// Progress describes how to read completion out of a command's stdout.
+type Progress struct {
+	// Total is the amount of work in the same unit Parse returns, e.g.
+	// seconds of media. Zero disables the display but still drains stdout.
+	Total float64
+	// Parse extracts the work done so far from one stdout line.
+	Parse func(line string) (float64, bool)
 }
 
 // Exec builds a command step.
@@ -200,8 +222,24 @@ func execute(job *Job, opts Options) error {
 
 	defer spinner.Stop()
 
+	started := time.Now()
+	report := func(done, total float64) {
+		if total <= 0 {
+			return
+		}
+
+		spinner.SetSuffix(
+			fmt.Sprintf(
+				"%s %s... %s",
+				opts.Verb,
+				job.Input,
+				progressText(done, total, time.Since(started)),
+			),
+		)
+	}
+
 	for _, step := range job.Steps {
-		err := runStep(step)
+		err := runStep(step, report)
 		if err != nil {
 			if !existed {
 				removeFile(job.Output)
@@ -218,7 +256,7 @@ func execute(job *Job, opts Options) error {
 	return nil
 }
 
-func runStep(step Step) error {
+func runStep(step Step, report func(done, total float64)) error {
 	if step.Cmd == nil {
 		log.Debug("step", "desc", step.Desc)
 
@@ -227,12 +265,78 @@ func runStep(step Step) error {
 
 	log.Debug("exec", "cmd", util.Describe(step.Cmd))
 
-	out, err := step.Cmd.CombinedOutput()
+	if step.Progress == nil {
+		out, err := step.Cmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%s: %w\n%s", step.Cmd.Args[0], err, tail(out))
+		}
+
+		return nil
+	}
+
+	return runWithProgress(step, report)
+}
+
+// runWithProgress streams the command's stdout through the step's parser so
+// the spinner can show how far along a long encode is. stderr is kept for
+// the error message.
+func runWithProgress(step Step, report func(done, total float64)) error {
+	var stderr bytes.Buffer
+
+	step.Cmd.Stderr = &stderr
+
+	stdout, err := step.Cmd.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("%s: %w\n%s", step.Cmd.Args[0], err, tail(out))
+		return fmt.Errorf("%s: %w", step.Cmd.Args[0], err)
+	}
+
+	err = step.Cmd.Start()
+	if err != nil {
+		return fmt.Errorf("%s: %w", step.Cmd.Args[0], err)
+	}
+
+	scanner := bufio.NewScanner(stdout)
+	for scanner.Scan() {
+		if done, ok := step.Progress.Parse(scanner.Text()); ok {
+			report(done, step.Progress.Total)
+		}
+	}
+
+	err = step.Cmd.Wait()
+	if err != nil {
+		return fmt.Errorf("%s: %w\n%s", step.Cmd.Args[0], err, tail(stderr.Bytes()))
 	}
 
 	return nil
+}
+
+// progressText renders "42% · 1:12 left" from work done, total work and the
+// time spent so far.
+func progressText(done, total float64, elapsed time.Duration) string {
+	frac := min(max(done/total, 0), 1)
+	text := fmt.Sprintf("%3.0f%%", frac*percent)
+
+	if frac > minProgressForETA && frac < 1 {
+		remaining := time.Duration(float64(elapsed) * (1 - frac) / frac).Round(time.Second)
+		text += " · " + clock(remaining) + " left"
+	}
+
+	return text
+}
+
+func clock(dur time.Duration) string {
+	secs := int(dur.Seconds())
+
+	if secs >= secondsPerHour {
+		return fmt.Sprintf(
+			"%d:%02d:%02d",
+			secs/secondsPerHour,
+			secs%secondsPerHour/secondsPerMin,
+			secs%secondsPerMin,
+		)
+	}
+
+	return fmt.Sprintf("%d:%02d", secs/secondsPerMin, secs%secondsPerMin)
 }
 
 // tail keeps the last lines of tool output and drops carriage-return progress

--- a/internal/job/job_test.go
+++ b/internal/job/job_test.go
@@ -1,0 +1,105 @@
+//nolint:testpackage
+package job
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func parseFake(line string) (float64, bool) {
+	value, ok := strings.CutPrefix(line, "done=")
+	if !ok {
+		return 0, false
+	}
+
+	secs, err := strconv.ParseFloat(value, 64)
+
+	return secs, err == nil
+}
+
+// TestRunStepReportsProgress tests that a step with a Progress parser streams
+// stdout through it and reports each parsed value against the total.
+func TestRunStepReportsProgress(t *testing.T) {
+	step := Step{
+		Cmd: exec.CommandContext(
+			context.Background(),
+			"sh",
+			"-c",
+			`printf 'done=0.5\nnoise\ndone=1.5\n'`,
+		),
+		Progress: &Progress{Total: 3, Parse: parseFake},
+	}
+
+	var got []float64
+
+	err := runStep(step, func(done, total float64) {
+		if total != 3 {
+			t.Errorf("total = %v; want 3", total)
+		}
+
+		got = append(got, done)
+	})
+	if err != nil {
+		t.Fatalf("runStep: %v", err)
+	}
+
+	if len(got) != 2 || got[0] != 0.5 || got[1] != 1.5 {
+		t.Errorf("reported %v; want [0.5 1.5]", got)
+	}
+}
+
+// TestRunStepProgressFailure tests that a failing progress step surfaces its
+// stderr in the error.
+func TestRunStepProgressFailure(t *testing.T) {
+	step := Step{
+		Cmd: exec.CommandContext(
+			context.Background(),
+			"sh",
+			"-c",
+			`echo "boom happened" >&2; exit 3`,
+		),
+		Progress: &Progress{Total: 1, Parse: parseFake},
+	}
+
+	err := runStep(step, func(float64, float64) {})
+	if err == nil || !strings.Contains(err.Error(), "boom happened") {
+		t.Fatalf("runStep error = %v; want stderr included", err)
+	}
+}
+
+// TestProgressText tests the percentage and ETA rendering.
+func TestProgressText(t *testing.T) {
+	tests := []struct {
+		done, total float64
+		elapsed     time.Duration
+		want        string
+	}{
+		{50, 100, 10 * time.Second, " 50% · 0:10 left"},
+		{25, 100, 30 * time.Second, " 25% · 1:30 left"},
+		{100, 100, time.Minute, "100%"},
+		{1, 100, time.Second, "  1%"},
+		{150, 100, time.Second, "100%"},
+	}
+	for _, testCase := range tests {
+		got := progressText(testCase.done, testCase.total, testCase.elapsed)
+		if got != testCase.want {
+			t.Errorf("progressText(%v, %v, %v) = %q; want %q",
+				testCase.done, testCase.total, testCase.elapsed, got, testCase.want)
+		}
+	}
+}
+
+// TestClock tests h:mm:ss rendering.
+func TestClock(t *testing.T) {
+	if got := clock(3725 * time.Second); got != "1:02:05" {
+		t.Errorf("clock(1h2m5s) = %q; want 1:02:05", got)
+	}
+
+	if got := clock(65 * time.Second); got != "1:05" {
+		t.Errorf("clock(65s) = %q; want 1:05", got)
+	}
+}


### PR DESCRIPTION
This PR replaces the indefinite spinner on video and audio encodes with live progress: percentage done and time remaining.

## What changed

- **Progress on encodes.** While ffmpeg runs, the spinner reads `Compressing clip.mp4... 42% · 1:12 left`. This applies to video compress, video convert (including remux), audio compress and audio convert. The percentage comes from ffmpeg's `-progress pipe:1` stream against the duration ffprobe reports for the input; without ffprobe the spinner behaves as before.
- **Runner support.** `job.Step` gains an optional `Progress` parser. Steps that have one stream stdout line by line while stderr is kept for the error message, so failure output is unchanged. `ffmpeg.Step` bundles the flags, the probe and the parser so each call site is still one line.
- Encodes now run with `-loglevel error`, which keeps ffmpeg's warning chatter out of failure messages.

Docs: the CLI reference notes the progress display under video compression.

## Why

Compressing a long recording is the slowest thing `uts` does, and a spinner alone gives no hint whether it is minutes or an hour. The ETA settles after the first couple of percent and is exact at the end.

## How to test

```bash
just lint && just test-all
ffmpeg -f lavfi -i testsrc2=duration=40:size=1280x720:rate=30 -pix_fmt yuv420p big.mp4
uts video compress big.mp4 -q high     # watch the percentage climb
uts video compress big.mp4 -q high --quiet   # no spinner, no output on success
```