### PR TITLE
feat(compress): add --max to cap the longest edge of images and video

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ uts image convert photo.heic --to jpg
 # Compress video in-place (replaces original recording)
 uts video compress recording.mp4 -i
 
+# Downscale a 4K recording to 1080p while compressing
+uts video compress recording.mov --max 1920
+
 # Convert MOV video to MP4 (stream copy when the codecs fit: instant and lossless)
 uts video convert clip.mov --to mp4
 
@@ -156,6 +159,7 @@ You don't need to install all of them – `uts` will intelligently work with wha
 - **Dry‑run preview**: Use `-n` (or `--dry-run`) to print the exact commands that would run, without making any changes.
 - **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in.
 - **Custom output directory**: Use `-o` (or `--output`) to specify where results are saved.
+- **Resize while you compress**: `--max 1920` shrinks images and videos so the longest edge is at most that many pixels. It keeps the aspect ratio and never enlarges.
 - **Lossless video conversion**: `video convert` copies the streams into the new container whenever the codecs allow, so `mov → mp4` takes a second and loses nothing. Pass `-q` to force a re-encode.
 - **Scripting**: `uts` exits `1` when any file fails, `--quiet` prints only warnings and errors, `uts info --json` emits machine-readable details, and `-v` logs every external command it runs. The banner is only shown on a terminal, so piped output stays clean.
 - **Shell completions**: `uts completion zsh|bash|fish` prints a completion script that also completes `--to` and `--algorithm` values. See the [Installation Guide](docs/INSTALLATION.md#shell-completions).

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -39,10 +39,16 @@ Target formats: ` + strings.Join(format.ImageTargets, ", "),
 		Example: `  uts image convert photo.heic --to jpg
   uts image convert screenshot.png --to webp -q high
   uts image convert photo.jpg --to avif -q 70
+  uts image convert photo.heic --to jpg --max 1600
   uts image convert ./photos --to jpg -r`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := requireTarget(format.ImageTargets)
+			if err != nil {
+				return err
+			}
+
+			err = checkMaxEdge()
 			if err != nil {
 				return err
 			}
@@ -61,10 +67,12 @@ Target formats: ` + strings.Join(format.ImageTargets, ", "),
 				OutputDir: outputDir,
 				InPlace:   inPlace,
 				DryRun:    dryRun,
+				MaxEdge:   maxEdge,
 			})
 		},
 	}
 	addTargetFlag(cmd, format.ImageTargets)
+	addMaxFlag(cmd)
 
 	return cmd
 }
@@ -77,17 +85,23 @@ func newVideoConvertCmd(use string, aliases []string) *cobra.Command {
 		Long: `Convert video files between containers using ffmpeg.
 
 When the source codecs already fit the target container the streams are
-copied without re-encoding: instant and lossless. Pass -q to force a
-re-encode at that quality.
+copied without re-encoding: instant and lossless. Pass -q or --max to
+force a re-encode.
 
 Target formats: ` + strings.Join(format.VideoTargets, ", "),
 		Example: `  uts video convert clip.mov --to mp4
   uts video convert recording.mkv --to webm -q medium
   uts video convert presentation.avi --to mkv -q 18
+  uts video convert clip.mov --to mp4 --max 1280
   uts video convert ./clips --to mp4`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := requireTarget(format.VideoTargets)
+			if err != nil {
+				return err
+			}
+
+			err = checkMaxEdge()
 			if err != nil {
 				return err
 			}
@@ -107,10 +121,12 @@ Target formats: ` + strings.Join(format.VideoTargets, ", "),
 				OutputDir:  outputDir,
 				InPlace:    inPlace,
 				DryRun:     dryRun,
+				MaxEdge:    maxEdge,
 			})
 		},
 	}
 	addTargetFlag(cmd, format.VideoTargets)
+	addMaxFlag(cmd)
 
 	return cmd
 }

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -42,9 +42,15 @@ original are reported and, with -i, the original is kept.`,
 	Example: `  uts image compress screenshot.png -q medium
   uts image compress logo.jpg -q high -i
   uts image compress ./photos -r
+  uts image compress photo.jpg --max 2000
   uts image compress '*.png' -q 75 --dry-run`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		err := checkMaxEdge()
+		if err != nil {
+			return err
+		}
+
 		files, err := inputs(args, format.ImageExts)
 		if err != nil {
 			return err
@@ -58,11 +64,13 @@ original are reported and, with -i, the original is kept.`,
 			OutputDir: outputDir,
 			InPlace:   inPlace,
 			DryRun:    dryRun,
+			MaxEdge:   maxEdge,
 		})
 	},
 }
 
 func init() {
+	addMaxFlag(imageCompressCmd)
 	imageCmd.AddCommand(imageCompressCmd)
 	imageCmd.AddCommand(newImageConvertCmd("convert", []string{"x"}))
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ var (
 	recursive bool
 	algorithm string
 	targetFmt string
+	maxEdge   int
 
 	// Version is the current version of uts, set at build time.
 	Version = "dev"
@@ -101,6 +102,29 @@ func requireTarget(valid []string) error {
 	}
 
 	return derrors.Newf(derrors.CodeInvalidInput, "missing --to <format>. Valid targets: %v", valid)
+}
+
+// minMaxEdge is the smallest --max value that makes sense for any media.
+const minMaxEdge = 16
+
+// addMaxFlag attaches the --max flag to an image or video command.
+func addMaxFlag(cmd *cobra.Command) {
+	cmd.Flags().IntVar(&maxEdge, "max", 0,
+		"Shrink so the longest edge is at most this many pixels (never enlarges)")
+}
+
+// checkMaxEdge validates --max.
+func checkMaxEdge() error {
+	if maxEdge != 0 && maxEdge < minMaxEdge {
+		return derrors.Newf(
+			derrors.CodeInvalidInput,
+			"--max must be at least %d pixels, got %d",
+			minMaxEdge,
+			maxEdge,
+		)
+	}
+
+	return nil
 }
 
 // addTargetFlag attaches the --to flag with shell completion for its values.

--- a/cmd/video.go
+++ b/cmd/video.go
@@ -38,9 +38,15 @@ Quality: high (crf=23, slow), medium (crf=28, medium), low (crf=32, fast), or ra
 	Example: `  uts video compress screen-recording.mp4 -q low
   uts video compress vacation.mov -q high -i
   uts video compress lecture.mkv -q 25 --dry-run
+  uts video compress 4k-screen-recording.mov --max 1920
   uts video compress ./recordings -r`,
 	Args: cobra.MinimumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		err := checkMaxEdge()
+		if err != nil {
+			return err
+		}
+
 		files, err := inputs(args, format.VideoExts)
 		if err != nil {
 			return err
@@ -54,11 +60,13 @@ Quality: high (crf=23, slow), medium (crf=28, medium), low (crf=32, fast), or ra
 			OutputDir: outputDir,
 			InPlace:   inPlace,
 			DryRun:    dryRun,
+			MaxEdge:   maxEdge,
 		})
 	},
 }
 
 func init() {
+	addMaxFlag(videoCompressCmd)
 	videoCmd.AddCommand(videoCompressCmd)
 	videoCmd.AddCommand(newVideoConvertCmd("convert", []string{"x"}))
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -63,6 +63,7 @@ When both `--output` and `--in-place` are given, `--in-place` is ignored with a 
 | ------------- | ----------------------- | --------------------------------------------------------- | ------- |
 | `--to`        | every `convert` command | Target format. Tab completion lists the valid values.     | _None_  |
 | `--algorithm` | `archive compress`      | Archive algorithm: `zip`, `gzip`, `zstd`, `xz`, `brotli`. | `zip`   |
+| `--max`       | image and video `compress` and `convert` | Shrink so the longest edge is at most this many pixels. Never enlarges, keeps the aspect ratio. Forces a re-encode for video. | _off_   |
 
 ---
 
@@ -102,6 +103,9 @@ uts video compress clip1.mp4 clip2.mp4 clip3.mp4 -q medium
 
 # Compress all MP4 files in subdirectories recursively
 uts video compress '*.mp4' -r -q medium
+
+# Downscale a 4K screen recording to 1080p while compressing
+uts video compress recording.mov --max 1920
 ```
 
 Conversion changes the container. When the source codecs already fit the target (for example H.264 + AAC from a `.mov` into `.mp4`) the streams are copied without re-encoding, which is instant and lossless. Otherwise the video is re-encoded at the `-q` quality. Passing `-q` explicitly always re-encodes.
@@ -133,6 +137,9 @@ uts image compress '**/*.jpg' -r
 
 # Compress HEIC photos down to a smaller profile size
 uts image compress photo.heic -q low
+
+# Shrink photos so the longest edge is 2000px, then compress
+uts image compress ./photos --max 2000 -r
 ```
 
 Conversion handles format shifting (e.g. modern formatting like `avif` or `webp`):

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -24,6 +24,17 @@ type ImageOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// MaxEdge caps the longest edge in pixels; 0 keeps the dimensions.
+	MaxEdge int
+}
+
+// maxNote describes a --max setting for the intro line.
+func maxNote(maxEdge int) string {
+	if maxEdge > 0 {
+		return fmt.Sprintf(", longest edge ≤ %dpx", maxEdge)
+	}
+
+	return ""
 }
 
 // Image compresses image files using the best tool available per format.
@@ -33,7 +44,12 @@ func Image(opts ImageOptions) error {
 		return err
 	}
 
-	ui.Message.Infof("Image compression at %s quality (value=%d)", opts.Quality, quality)
+	ui.Message.Infof(
+		"Image compression at %s quality (value=%d)%s",
+		opts.Quality,
+		quality,
+		maxNote(opts.MaxEdge),
+	)
 
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Compressing",
@@ -44,11 +60,11 @@ func Image(opts ImageOptions) error {
 		DryRun:  opts.DryRun,
 		Code:    derrors.CodeCompressionFailed,
 	}, func(file string) (*job.Job, error) {
-		return planImage(file, quality, opts.OutputDir)
+		return planImage(file, quality, opts.MaxEdge, opts.OutputDir)
 	})
 }
 
-func planImage(file string, quality int, outputDir string) (*job.Job, error) {
+func planImage(file string, quality, maxEdge int, outputDir string) (*job.Job, error) {
 	ext := format.Ext(file)
 	out := util.CalcOutputPath(file, "small", outputDir)
 
@@ -60,20 +76,20 @@ func planImage(file string, quality int, outputDir string) (*job.Job, error) {
 
 	switch ext {
 	case "png":
-		tool, steps, err = pngSteps(file, out, quality)
+		tool, steps, err = pngSteps(file, out, quality, maxEdge)
 	case "jpg", "jpeg":
-		tool, steps, err = jpegSteps(file, out, quality)
+		tool, steps, err = jpegSteps(file, out, quality, maxEdge)
 	case "webp":
-		tool, steps, err = webpSteps(file, out, quality)
+		tool, steps, err = webpSteps(file, out, quality, maxEdge)
 	case "gif":
-		tool, steps, err = gifSteps(file, out)
+		tool, steps, err = gifSteps(file, out, maxEdge)
 	case "heic", "heif":
 		// HEIC has no lossy re-encoder in common toolchains; JPEG is the
 		// portable result users expect from "compress this photo".
 		out = util.CalcOutputPathExt(file, "small", "jpg", outputDir)
-		tool, steps, err = heicSteps(file, out, quality)
+		tool, steps, err = heicSteps(file, out, quality, maxEdge)
 	case "bmp", "tiff", "tif", "avif", "avifs":
-		tool, steps, err = magickSteps(file, out, quality)
+		tool, steps, err = magickSteps(file, out, quality, maxEdge)
 	default:
 		return nil, derrors.Newf(derrors.CodeUnsupportedFormat, "unsupported image format .%s", ext)
 	}
@@ -85,13 +101,58 @@ func planImage(file string, quality int, outputDir string) (*job.Job, error) {
 	return &job.Job{Input: file, Output: out, Steps: steps, Note: "via " + tool}, nil
 }
 
-func pngSteps(file, out string, quality int) (string, []job.Step, error) {
+// pngSteps compresses a PNG. With a size cap ImageMagick writes the resized
+// file first and pngquant then quantizes it in place.
+func pngSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {
 	switch {
 	case util.HasTool("pngquant"):
-		steps := []job.Step{job.Exec("pngquant",
-			fmt.Sprintf("--quality=%d-%d", max(quality-10, 0), quality),
-			"--speed", "1", "--strip", "--force", "--output", out, "--", file)}
-		tool := "pngquant"
+		quant := fmt.Sprintf("--quality=%d-%d", max(quality-10, 0), quality)
+
+		var (
+			steps []job.Step
+			tool  string
+		)
+
+		if maxEdge > 0 {
+			resize, err := resizeStep(file, out, maxEdge)
+			if err != nil {
+				return "", nil, err
+			}
+
+			steps = append(
+				steps,
+				resize,
+				job.Exec(
+					"pngquant",
+					quant,
+					"--speed",
+					"1",
+					"--strip",
+					"--force",
+					"--ext",
+					".png",
+					out,
+				),
+			)
+			tool = "ImageMagick + pngquant"
+		} else {
+			steps = append(
+				steps,
+				job.Exec(
+					"pngquant",
+					quant,
+					"--speed",
+					"1",
+					"--strip",
+					"--force",
+					"--output",
+					out,
+					"--",
+					file,
+				),
+			)
+			tool = "pngquant"
+		}
 
 		if util.HasTool("optipng") {
 			steps = append(steps, job.Exec("optipng", "-quiet", "-o2", out))
@@ -100,65 +161,114 @@ func pngSteps(file, out string, quality int) (string, []job.Step, error) {
 
 		return tool, steps, nil
 	case util.HasTool("optipng"):
-		return "optipng", []job.Step{
-			copyStep(file, out),
-			job.Exec("optipng", "-quiet", "-o2", out),
-		}, nil
+		first, err := stageStep(file, out, maxEdge)
+		if err != nil {
+			return "", nil, err
+		}
+
+		return "optipng", []job.Step{first, job.Exec("optipng", "-quiet", "-o2", out)}, nil
 	}
 
-	return magickSteps(file, out, quality)
+	return magickSteps(file, out, quality, maxEdge)
 }
 
-func jpegSteps(file, out string, quality int) (string, []job.Step, error) {
+func jpegSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {
 	if util.HasTool("jpegoptim") {
+		first, err := stageStep(file, out, maxEdge)
+		if err != nil {
+			return "", nil, err
+		}
+
 		return "jpegoptim", []job.Step{
-			copyStep(file, out),
+			first,
 			job.Exec("jpegoptim", fmt.Sprintf("--max=%d", quality), "--strip-all", "--quiet", out),
 		}, nil
 	}
 
-	return magickSteps(file, out, quality)
+	return magickSteps(file, out, quality, maxEdge)
 }
 
-func webpSteps(file, out string, quality int) (string, []job.Step, error) {
-	if util.HasTool("cwebp") {
+func webpSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {
+	if util.HasTool("cwebp") && maxEdge == 0 {
 		return "cwebp", []job.Step{
 			job.Exec("cwebp", "-quiet", "-q", strconv.Itoa(quality), "-m", "6", file, "-o", out),
 		}, nil
 	}
 
-	return magickSteps(file, out, quality)
+	return magickSteps(file, out, quality, maxEdge)
 }
 
-func gifSteps(file, out string) (string, []job.Step, error) {
+func gifSteps(file, out string, maxEdge int) (string, []job.Step, error) {
 	if util.HasTool("gifsicle") {
-		return "gifsicle", []job.Step{
-			job.Exec("gifsicle", "-O3", "--lossy=80", file, "-o", out),
-		}, nil
+		args := []string{"-O3", "--lossy=80"}
+		if maxEdge > 0 {
+			args = append(args, "--resize-fit", fmt.Sprintf("%dx%d", maxEdge, maxEdge))
+		}
+
+		return "gifsicle", []job.Step{job.Exec("gifsicle", append(args, file, "-o", out)...)}, nil
 	}
 
-	return magickSteps(file, out, 80)
+	return magickSteps(file, out, 80, maxEdge)
 }
 
-func heicSteps(file, out string, quality int) (string, []job.Step, error) {
-	if util.HasTool("heif-convert") {
+func heicSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {
+	if util.HasTool("heif-convert") && maxEdge == 0 {
 		return "heif-convert", []job.Step{
 			job.Exec("heif-convert", "-q", strconv.Itoa(quality), file, out),
 		}, nil
 	}
 
-	return magickSteps(file, out, quality)
+	return magickSteps(file, out, quality, maxEdge)
 }
 
-func magickSteps(file, out string, quality int) (string, []job.Step, error) {
+func magickSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {
 	bin := util.MagickBin()
 	if bin == "" {
 		return "", nil, errImageMagick
 	}
 
-	return "ImageMagick", []job.Step{
-		job.Exec(bin, file, "-quality", strconv.Itoa(quality), "-strip", out),
-	}, nil
+	args := make([]string, 0, 7)
+	args = append(args, file)
+	args = append(args, resizeArgs(maxEdge)...)
+	args = append(args, "-quality", strconv.Itoa(quality), "-strip", out)
+
+	return "ImageMagick", []job.Step{job.Exec(bin, args...)}, nil
+}
+
+// resizeArgs returns ImageMagick arguments that shrink the longest edge to
+// maxEdge, never enlarging. Empty when no cap is set.
+func resizeArgs(maxEdge int) []string {
+	if maxEdge <= 0 {
+		return nil
+	}
+
+	return []string{"-resize", fmt.Sprintf("%dx%d>", maxEdge, maxEdge)}
+}
+
+// resizeStep writes a resized copy of file to out with ImageMagick.
+func resizeStep(file, out string, maxEdge int) (job.Step, error) {
+	bin := util.MagickBin()
+	if bin == "" {
+		return job.Step{}, derrors.New(derrors.CodeToolNotFound,
+			"--max needs ImageMagick for this format — install: brew install imagemagick")
+	}
+
+	args := make([]string, 0, 4)
+	args = append(args, file)
+	args = append(args, resizeArgs(maxEdge)...)
+	args = append(args, out)
+
+	return job.Exec(bin, args...), nil
+}
+
+// stageStep places the working copy at out: a plain copy, or a resized copy
+// when a size cap is set. In-place tools then operate on out.
+func stageStep(file, out string, maxEdge int) (job.Step, error) {
+	if maxEdge > 0 {
+		return resizeStep(file, out, maxEdge)
+	}
+
+	return copyStep(file, out), nil
 }
 
 func copyStep(src, dst string) job.Step {

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -19,6 +19,8 @@ type VideoOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// MaxEdge caps the longest edge in pixels; 0 keeps the resolution.
+	MaxEdge int
 }
 
 // Video compresses video files using ffmpeg, keeping the input container.
@@ -34,10 +36,11 @@ func Video(opts VideoOptions) error {
 	}
 
 	ui.Message.Infof(
-		"Video compression at %s quality (crf=%d, preset=%s)",
+		"Video compression at %s quality (crf=%d, preset=%s)%s",
 		opts.Quality,
 		crf,
 		preset,
+		maxNote(opts.MaxEdge),
 	)
 
 	return job.Run(opts.Files, job.Options{
@@ -65,7 +68,7 @@ func Video(opts VideoOptions) error {
 			Input:  file,
 			Output: out,
 			Steps: []job.Step{
-				ffmpeg.Step(file, ffmpeg.EncodeArgs(file, out, ext, crf, preset)...),
+				ffmpeg.Step(file, ffmpeg.EncodeArgs(file, out, ext, crf, preset, opts.MaxEdge)...),
 			},
 			Note: fmt.Sprintf("%s/%s crf=%d", vcodec, acodec, crf),
 		}, nil

--- a/internal/convert/image.go
+++ b/internal/convert/image.go
@@ -22,6 +22,8 @@ type ImageOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// MaxEdge caps the longest edge in pixels; 0 keeps the dimensions.
+	MaxEdge int
 }
 
 // sipsTargets are the formats macOS sips can write, used when ImageMagick is
@@ -40,7 +42,12 @@ func Image(opts ImageOptions) error {
 		return err
 	}
 
-	ui.Message.Infof("Converting images to .%s (quality=%d)", target, quality)
+	ui.Message.Infof(
+		"Converting images to .%s (quality=%d)%s",
+		target,
+		quality,
+		maxNote(opts.MaxEdge),
+	)
 
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Converting",
@@ -65,7 +72,7 @@ func Image(opts ImageOptions) error {
 
 		out := util.CalcConvertOutputPath(file, target, opts.OutputDir)
 
-		tool, step, err := imageStep(file, out, ext, target, quality)
+		tool, step, err := imageStep(file, out, ext, target, quality, opts.MaxEdge)
 		if err != nil {
 			return nil, err
 		}
@@ -79,8 +86,9 @@ func Image(opts ImageOptions) error {
 	})
 }
 
-func imageStep(file, out, ext, target string, quality int) (string, job.Step, error) {
-	if target == "avif" && (ext == "png" || ext == "jpg" || ext == "jpeg") {
+func imageStep(file, out, ext, target string, quality, maxEdge int) (string, job.Step, error) {
+	// cavif and avifenc cannot resize, so a size cap goes through ImageMagick.
+	if target == "avif" && maxEdge == 0 && (ext == "png" || ext == "jpg" || ext == "jpeg") {
 		switch {
 		case util.HasTool("cavif"):
 			return "cavif", job.Exec(
@@ -111,14 +119,14 @@ func imageStep(file, out, ext, target string, quality int) (string, job.Step, er
 	}
 
 	if bin := util.MagickBin(); bin != "" {
-		return "ImageMagick", job.Exec(
-			bin,
-			file,
-			"-quality",
-			strconv.Itoa(quality),
-			"-strip",
-			out,
-		), nil
+		args := []string{file}
+		if maxEdge > 0 {
+			args = append(args, "-resize", fmt.Sprintf("%dx%d>", maxEdge, maxEdge))
+		}
+
+		args = append(args, "-quality", strconv.Itoa(quality), "-strip", out)
+
+		return "ImageMagick", job.Exec(bin, args...), nil
 	}
 
 	if util.HasTool("sips") && slices.Contains(sipsTargets, target) {
@@ -127,11 +135,27 @@ func imageStep(file, out, ext, target string, quality int) (string, job.Step, er
 			sipsFmt = "jpeg"
 		}
 
-		return "sips", job.Exec("sips", "-s", "format", sipsFmt, file, "--out", out), nil
+		args := []string{}
+		if maxEdge > 0 {
+			args = append(args, "-Z", strconv.Itoa(maxEdge))
+		}
+
+		args = append(args, "-s", "format", sipsFmt, file, "--out", out)
+
+		return "sips", job.Exec("sips", args...), nil
 	}
 
 	return "", job.Step{}, derrors.New(derrors.CodeToolNotFound,
 		"ImageMagick not found — install: brew install imagemagick")
+}
+
+// maxNote describes a --max setting for the intro line.
+func maxNote(maxEdge int) string {
+	if maxEdge > 0 {
+		return fmt.Sprintf(", longest edge ≤ %dpx", maxEdge)
+	}
+
+	return ""
 }
 
 func unsupportedTarget(target string, valid []string) error {

--- a/internal/convert/video.go
+++ b/internal/convert/video.go
@@ -25,6 +25,8 @@ type VideoOptions struct {
 	OutputDir  string
 	InPlace    bool
 	DryRun     bool
+	// MaxEdge caps the longest edge in pixels; it always implies a re-encode.
+	MaxEdge int
 }
 
 // Video converts video files to the target container.
@@ -45,7 +47,14 @@ func Video(opts VideoOptions) error {
 	}
 
 	vcodec, acodec := format.VideoCodecs(target)
-	ui.Message.Infof("Converting video to .%s (%s/%s, crf=%d)", target, vcodec, acodec, crf)
+	ui.Message.Infof(
+		"Converting video to .%s (%s/%s, crf=%d)%s",
+		target,
+		vcodec,
+		acodec,
+		crf,
+		maxNote(opts.MaxEdge),
+	)
 
 	return job.Run(opts.Files, job.Options{
 		Verb:    "Converting",
@@ -70,7 +79,7 @@ func Video(opts VideoOptions) error {
 
 		out := util.CalcConvertOutputPath(file, target, opts.OutputDir)
 
-		if !opts.QualitySet {
+		if !opts.QualitySet && opts.MaxEdge == 0 {
 			info, probeErr := ffmpeg.Probe(file)
 			if probeErr == nil && ffmpeg.CanRemux(info, target) {
 				return &job.Job{
@@ -86,7 +95,9 @@ func Video(opts VideoOptions) error {
 			Input:  file,
 			Output: out,
 			Steps: []job.Step{
-				ffmpeg.Step(file, ffmpeg.EncodeArgs(file, out, target, crf, preset)...),
+				ffmpeg.Step(
+					file,
+					ffmpeg.EncodeArgs(file, out, target, crf, preset, opts.MaxEdge)...),
 			},
 			Note: fmt.Sprintf("%s/%s crf=%d preset=%s", vcodec, acodec, crf, preset),
 		}, nil

--- a/internal/ffmpeg/ffmpeg.go
+++ b/internal/ffmpeg/ffmpeg.go
@@ -82,7 +82,9 @@ func Check() error {
 //   - VP9 needs -b:v 0 for CRF to mean constant quality, and speed is set via
 //     -cpu-used because it has no -preset
 //   - mp4/mov get +faststart so playback can begin before download ends
-func EncodeArgs(input, out, container string, crf int, preset string) []string {
+//   - maxEdge > 0 adds a scale filter that shrinks the longest edge to at
+//     most that many pixels, never enlarging
+func EncodeArgs(input, out, container string, crf int, preset string, maxEdge int) []string {
 	container = format.Normalize(strings.TrimPrefix(container, "."))
 	vcodec, acodec := format.VideoCodecs(container)
 
@@ -110,6 +112,10 @@ func EncodeArgs(input, out, container string, crf int, preset string) []string {
 		}
 	}
 
+	if maxEdge > 0 {
+		args = append(args, "-vf", ScaleFilter(maxEdge))
+	}
+
 	args = append(args, "-c:a", acodec, "-b:a", "128k")
 
 	if container == "mp4" || container == "mov" || container == "m4v" {
@@ -117,6 +123,15 @@ func EncodeArgs(input, out, container string, crf int, preset string) []string {
 	}
 
 	return append(args, "-y", out)
+}
+
+// ScaleFilter returns an ffmpeg scale filter that caps the longest edge at
+// maxEdge pixels while keeping the aspect ratio and even dimensions. Smaller
+// inputs pass through unchanged.
+func ScaleFilter(maxEdge int) string {
+	edge := strconv.Itoa(maxEdge)
+
+	return "scale='if(gt(iw,ih),min(" + edge + ",iw),-2)':'if(gt(iw,ih),-2,min(" + edge + ",ih))'"
 }
 
 func vp9Speed(preset string) string {

--- a/internal/ffmpeg/ffmpeg_test.go
+++ b/internal/ffmpeg/ffmpeg_test.go
@@ -16,7 +16,7 @@ func has(args []string, want ...string) bool {
 }
 
 func TestEncodeArgsVP9(t *testing.T) {
-	args := ffmpeg.EncodeArgs("in.mp4", "out.webm", "webm", 30, "fast")
+	args := ffmpeg.EncodeArgs("in.mp4", "out.webm", "webm", 30, "fast", 0)
 
 	if !has(args, "-c:v", "libvpx-vp9") || !has(args, "-b:v", "0") || !has(args, "-cpu-used", "4") {
 		t.Errorf("VP9 args missing constant-quality flags: %v", args)
@@ -28,7 +28,7 @@ func TestEncodeArgsVP9(t *testing.T) {
 }
 
 func TestEncodeArgsMP4(t *testing.T) {
-	args := ffmpeg.EncodeArgs("in.mov", "out.mp4", ".mp4", 23, "slow")
+	args := ffmpeg.EncodeArgs("in.mov", "out.mp4", ".mp4", 23, "slow", 0)
 
 	for _, want := range [][]string{
 		{"-c:v", "libx264"},
@@ -49,12 +49,29 @@ func TestEncodeArgsMP4(t *testing.T) {
 }
 
 func TestEncodeArgsHEVCTag(t *testing.T) {
-	if !has(ffmpeg.EncodeArgs("a", "b", "mkv", 28, "medium"), "-c:v", "libx265") {
+	if !has(ffmpeg.EncodeArgs("a", "b", "mkv", 28, "medium", 0), "-c:v", "libx265") {
 		t.Error("mkv should use libx265")
 	}
 
-	if has(ffmpeg.EncodeArgs("a", "b", "mkv", 28, "medium"), "-tag:v", "hvc1") {
+	if has(ffmpeg.EncodeArgs("a", "b", "mkv", 28, "medium", 0), "-tag:v", "hvc1") {
 		t.Error("hvc1 tag only applies to mp4/mov")
+	}
+}
+
+func TestEncodeArgsMaxEdge(t *testing.T) {
+	args := ffmpeg.EncodeArgs("in.mov", "out.mp4", "mp4", 28, "medium", 1920)
+	if !has(args, "-vf", ffmpeg.ScaleFilter(1920)) {
+		t.Errorf("maxEdge should add a scale filter: %v", args)
+	}
+
+	if slices.Contains(ffmpeg.EncodeArgs("in.mov", "out.mp4", "mp4", 28, "medium", 0), "-vf") {
+		t.Error("maxEdge 0 must not add a scale filter")
+	}
+
+	filter := ffmpeg.ScaleFilter(1080)
+	if !strings.Contains(filter, "min(1080,iw)") || !strings.Contains(filter, "min(1080,ih)") ||
+		!strings.Contains(filter, "-2") {
+		t.Errorf("ScaleFilter(1080) = %q", filter)
 	}
 }
 


### PR DESCRIPTION
This PR adds `--max <px>` to image and video compress and convert, so "make this 4K recording 1080p" and "shrink these photos to 2000px" are one flag away.

## What changed

- **`--max <px>`** on `image compress`, `image convert`, `video compress` and `video convert` shrinks the result so its longest edge is at most that many pixels. It keeps the aspect ratio, never enlarges, and works for portrait and landscape alike. Values below 16 are rejected.
- **Video** gets an ffmpeg scale filter that keeps dimensions even. Because resizing always re-encodes, `--max` also disables the stream-copy path in `video convert`, the same way `-q` does. A 1280x720 test clip at `--max 640` came out 640x360 and 92% smaller.
- **Images** are resized by ImageMagick into the output first, then the format's tool works in place: pngquant with `--ext`, jpegoptim, optipng. gifsicle uses its own `--resize-fit`, and sips uses `-Z` when ImageMagick is missing. Formats whose dedicated tool cannot resize (cwebp, heif-convert, cavif, avifenc) fall back to ImageMagick when `--max` is set, with a clear error if it is not installed.

Docs: CLI reference lists `--max` in Command Options with examples; README gains a "Resize while you compress" bullet and example.

## Why

Resolution is the biggest lever on file size and none of the quality presets touched it. Downscaling a screen recording or camera export is the most common real compression request.

## How to test

```bash
just lint && just test-all
uts video compress recording.mov --max 1920        # 1080p output
uts image compress ./photos --max 2000 -r
uts image convert photo.heic --to jpg --max 1600
uts image compress x.png --max 5; echo $?          # "--max must be at least 16 pixels", exit 1
```