### PR TITLE
feat(cli): add -j parallel jobs, --skip-existing and --backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ uts audio convert track.wav --to mp3 -q high
 # Compress PDF document to a medium-res profile
 uts pdf compress draft.pdf -q medium
 
-# Compress every image in a folder tree
-uts image compress ./photos -r
+# Compress every image in a folder tree, using every core
+uts image compress ./photos -r -j 0
 
 # Compress folder to a zstd tarball archive
 uts archive compress ./project/ --algorithm zstd
@@ -157,7 +157,8 @@ You don't need to install all of them – `uts` will intelligently work with wha
 
 - **Batch processing**: Pass files, directories, or quoted globs. A directory expands to the media files inside it, and `-r` (or `--recursive`) walks the whole tree.
 - **Dry‑run preview**: Use `-n` (or `--dry-run`) to print the exact commands that would run, without making any changes.
-- **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in.
+- **In‑place replacement**: Use `-i` (or `--in-place`) to overwrite the original file. A result that is not smaller than the original is never swapped in, and `--backup` keeps the original as `<name>.bak`.
+- **Big batches**: `-j 0` processes one file per CPU core, and `--skip-existing` lets you re-run an interrupted batch without redoing finished files.
 - **Custom output directory**: Use `-o` (or `--output`) to specify where results are saved.
 - **Resize while you compress**: `--max 1920` shrinks images and videos so the longest edge is at most that many pixels. It keeps the aspect ratio and never enlarges.
 - **Lossless video conversion**: `video convert` copies the streams into the new container whenever the codecs allow, so `mov → mp4` takes a second and loses nothing. Pass `-q` to force a re-encode.

--- a/cmd/audio.go
+++ b/cmd/audio.go
@@ -51,11 +51,14 @@ Quality: high (192k), medium (128k), low (96k), or raw kbps.`,
 		log.Debug("compressing audio files", "files", files)
 
 		return compress.Audio(compress.AudioOptions{
-			Files:     files,
-			Quality:   quality,
-			OutputDir: outputDir,
-			InPlace:   inPlace,
-			DryRun:    dryRun,
+			Files:        files,
+			Quality:      quality,
+			OutputDir:    outputDir,
+			InPlace:      inPlace,
+			DryRun:       dryRun,
+			Jobs:         jobs,
+			SkipExisting: skipExisting,
+			Backup:       backup,
 		})
 	},
 }

--- a/cmd/convert.go
+++ b/cmd/convert.go
@@ -61,13 +61,16 @@ Target formats: ` + strings.Join(format.ImageTargets, ", "),
 			log.Debug("converting image files", "files", files, "target", targetFmt)
 
 			return convert.Image(convert.ImageOptions{
-				Files:     files,
-				Target:    targetFmt,
-				Quality:   quality,
-				OutputDir: outputDir,
-				InPlace:   inPlace,
-				DryRun:    dryRun,
-				MaxEdge:   maxEdge,
+				Files:        files,
+				Target:       targetFmt,
+				Quality:      quality,
+				OutputDir:    outputDir,
+				InPlace:      inPlace,
+				DryRun:       dryRun,
+				Jobs:         jobs,
+				SkipExisting: skipExisting,
+				Backup:       backup,
+				MaxEdge:      maxEdge,
 			})
 		},
 	}
@@ -114,14 +117,17 @@ Target formats: ` + strings.Join(format.VideoTargets, ", "),
 			log.Debug("converting video files", "files", files, "target", targetFmt)
 
 			return convert.Video(convert.VideoOptions{
-				Files:      files,
-				Target:     targetFmt,
-				Quality:    quality,
-				QualitySet: cmd.Flags().Changed("quality"),
-				OutputDir:  outputDir,
-				InPlace:    inPlace,
-				DryRun:     dryRun,
-				MaxEdge:    maxEdge,
+				Files:        files,
+				Target:       targetFmt,
+				Quality:      quality,
+				QualitySet:   cmd.Flags().Changed("quality"),
+				OutputDir:    outputDir,
+				InPlace:      inPlace,
+				DryRun:       dryRun,
+				Jobs:         jobs,
+				SkipExisting: skipExisting,
+				Backup:       backup,
+				MaxEdge:      maxEdge,
 			})
 		},
 	}
@@ -158,12 +164,15 @@ Target formats: ` + strings.Join(format.AudioTargets, ", "),
 			log.Debug("converting audio files", "files", files, "target", targetFmt)
 
 			return convert.Audio(convert.AudioOptions{
-				Files:     files,
-				Target:    targetFmt,
-				Quality:   quality,
-				OutputDir: outputDir,
-				InPlace:   inPlace,
-				DryRun:    dryRun,
+				Files:        files,
+				Target:       targetFmt,
+				Quality:      quality,
+				OutputDir:    outputDir,
+				InPlace:      inPlace,
+				DryRun:       dryRun,
+				Jobs:         jobs,
+				SkipExisting: skipExisting,
+				Backup:       backup,
 			})
 		},
 	}
@@ -200,11 +209,14 @@ images → PDF: combines the images, in order, into a single PDF`,
 			log.Debug("converting PDF files", "files", files, "target", targetFmt)
 
 			return convert.PDF(convert.PDFOptions{
-				Files:     files,
-				Target:    targetFmt,
-				Quality:   quality,
-				OutputDir: outputDir,
-				DryRun:    dryRun,
+				Files:        files,
+				Target:       targetFmt,
+				Quality:      quality,
+				OutputDir:    outputDir,
+				DryRun:       dryRun,
+				Jobs:         jobs,
+				SkipExisting: skipExisting,
+				Backup:       backup,
 			})
 		},
 	}

--- a/cmd/image.go
+++ b/cmd/image.go
@@ -59,12 +59,15 @@ original are reported and, with -i, the original is kept.`,
 		log.Debug("compressing image files", "files", files)
 
 		return compress.Image(compress.ImageOptions{
-			Files:     files,
-			Quality:   quality,
-			OutputDir: outputDir,
-			InPlace:   inPlace,
-			DryRun:    dryRun,
-			MaxEdge:   maxEdge,
+			Files:        files,
+			Quality:      quality,
+			OutputDir:    outputDir,
+			InPlace:      inPlace,
+			DryRun:       dryRun,
+			Jobs:         jobs,
+			SkipExisting: skipExisting,
+			Backup:       backup,
+			MaxEdge:      maxEdge,
 		})
 	},
 }

--- a/cmd/pdf.go
+++ b/cmd/pdf.go
@@ -45,11 +45,14 @@ Quality: high (400 DPI, /printer), medium (300 DPI, /ebook), low (150 DPI, /scre
 		log.Debug("compressing PDF files", "files", files)
 
 		return compress.PDF(compress.PDFOptions{
-			Files:     files,
-			Quality:   quality,
-			OutputDir: outputDir,
-			InPlace:   inPlace,
-			DryRun:    dryRun,
+			Files:        files,
+			Quality:      quality,
+			OutputDir:    outputDir,
+			InPlace:      inPlace,
+			DryRun:       dryRun,
+			Jobs:         jobs,
+			SkipExisting: skipExisting,
+			Backup:       backup,
 		})
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"runtime"
 
 	"charm.land/log/v2"
 	"github.com/spf13/cobra"
@@ -11,16 +12,19 @@ import (
 )
 
 var (
-	quality   string
-	outputDir string
-	inPlace   bool
-	dryRun    bool
-	verbose   bool
-	quiet     bool
-	recursive bool
-	algorithm string
-	targetFmt string
-	maxEdge   int
+	quality      string
+	outputDir    string
+	inPlace      bool
+	dryRun       bool
+	verbose      bool
+	quiet        bool
+	recursive    bool
+	jobs         int
+	skipExisting bool
+	backup       bool
+	algorithm    string
+	targetFmt    string
+	maxEdge      int
 
 	// Version is the current version of uts, set at build time.
 	Version = "dev"
@@ -68,6 +72,23 @@ func Execute() error {
 		}
 
 		ui.SetQuiet(quiet && !verbose)
+
+		switch {
+		case jobs < 0:
+			return derrors.Newf(
+				derrors.CodeInvalidInput,
+				"--jobs must be 0 (all cores) or a positive number, got %d",
+				jobs,
+			)
+		case jobs == 0:
+			jobs = runtime.NumCPU()
+		}
+
+		if backup && !inPlace {
+			ui.Message.Warnf(
+				"--backup only applies with --in-place; originals are untouched anyway",
+			)
+		}
 
 		if inPlace && outputDir != "" {
 			ui.Message.Warnf("--in-place is ignored when --output is set; originals are kept")
@@ -160,6 +181,12 @@ func init() {
 		"Only print warnings and errors")
 	RootCmd.PersistentFlags().BoolVarP(&recursive, "recursive", "r", false,
 		"Recurse into directories and expand '**' glob patterns")
+	RootCmd.PersistentFlags().IntVarP(&jobs, "jobs", "j", 1,
+		"Process this many files at once (0 = one per CPU core)")
+	RootCmd.PersistentFlags().BoolVar(&skipExisting, "skip-existing", false,
+		"Skip files whose output already exists (resume an interrupted batch)")
+	RootCmd.PersistentFlags().BoolVar(&backup, "backup", false,
+		"With --in-place, keep the original as <name>.bak")
 
 	RootCmd.AddCommand(videoCmd)
 	RootCmd.AddCommand(imageCmd)

--- a/cmd/video.go
+++ b/cmd/video.go
@@ -55,12 +55,15 @@ Quality: high (crf=23, slow), medium (crf=28, medium), low (crf=32, fast), or ra
 		log.Debug("compressing video files", "files", files)
 
 		return compress.Video(compress.VideoOptions{
-			Files:     files,
-			Quality:   quality,
-			OutputDir: outputDir,
-			InPlace:   inPlace,
-			DryRun:    dryRun,
-			MaxEdge:   maxEdge,
+			Files:        files,
+			Quality:      quality,
+			OutputDir:    outputDir,
+			InPlace:      inPlace,
+			DryRun:       dryRun,
+			Jobs:         jobs,
+			SkipExisting: skipExisting,
+			Backup:       backup,
+			MaxEdge:      maxEdge,
 		})
 	},
 }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -52,6 +52,9 @@ These options apply to commands across all categories:
 | `-v` | `--verbose`   | Log every external command that runs, plus debug output.                         | `false`            |
 |      | `--quiet`     | Print only warnings and errors. Spinners and progress are suppressed too.        | `false`            |
 | `-r` | `--recursive` | Walk directories recursively and expand `**` glob patterns.                      | `false`            |
+| `-j` | `--jobs`      | Process this many files at once. `0` means one per CPU core. Best for image, audio and PDF batches; ffmpeg already uses every core for a single video. | `1` |
+|      | `--skip-existing` | Skip files whose output already exists, so an interrupted batch can be re-run. | `false`        |
+|      | `--backup`    | With `--in-place`, keep the original as `<name>.bak`.                            | `false`            |
 | `-h` | `--help`      | Display syntax, actions, and options helper info.                                |                    |
 |      | `--version`   | Display version, commit hash, and build timestamp.                               |                    |
 
@@ -104,6 +107,9 @@ uts video compress clip1.mp4 clip2.mp4 clip3.mp4 -q medium
 # Compress all MP4 files in subdirectories recursively
 uts video compress '*.mp4' -r -q medium
 
+# Replace originals but keep a .bak copy of each
+uts video compress ./clips -i --backup
+
 # Downscale a 4K screen recording to 1080p while compressing
 uts video compress recording.mov --max 1920
 ```
@@ -134,6 +140,9 @@ uts image compress logo.jpg -q high -i
 
 # Find and compress all JPG files recursively
 uts image compress '**/*.jpg' -r
+
+# Compress a large folder using every core, resumable if interrupted
+uts image compress ./photos -r -j 0 --skip-existing
 
 # Compress HEIC photos down to a smaller profile size
 uts image compress photo.heic -q low
@@ -247,7 +256,9 @@ uts convert pdf report.pdf --to jpg
 
 - **Default suffix**: Compression writes `<name>-small.<ext>` next to the input. Conversion writes `<name>.<target>` next to the input.
 - **Output directories**: With `--output <dir>`, compression writes `<dir>/<name>.<ext>` and conversion writes `<dir>/<name>.<target>`.
-- **In-place**: `--in-place` replaces the original with the result. For conversions the original is removed and the result takes its base name.
+- **In-place**: `--in-place` replaces the original with the result. For conversions the original is removed and the result takes its base name. Add `--backup` to keep the original as `<name>.bak`.
+- **Resuming**: `--skip-existing` leaves any file alone whose output is already on disk, so re-running the same command after an interruption only processes what is left.
+- **Parallelism**: `-j 4` runs four files at once. Each file's messages are printed together when it finishes, so output never interleaves.
 - **Not smaller**: When a compressed result is not smaller than the original, `uts` says so. With `--in-place` the original is kept and the result discarded.
 - **Priority**: If both `--output` and `--in-place` are defined, `--in-place` is ignored to prevent accidental source deletions.
 - **Failures**: A failed step removes its partial output, every remaining file is still processed, and `uts` exits `1`.

--- a/internal/compress/audio.go
+++ b/internal/compress/audio.go
@@ -19,6 +19,10 @@ type AudioOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 }
 
 // Audio compresses audio files using ffmpeg. Lossy inputs keep their format;
@@ -37,13 +41,16 @@ func Audio(opts AudioOptions) error {
 	ui.Message.Infof("Audio compression at %s quality (bitrate=%s)", opts.Quality, bitrate)
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Compressing",
-		Done:    "Compressed",
-		Noun:    "audio file",
-		Compare: true,
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeCompressionFailed,
+		Verb:         "Compressing",
+		Done:         "Compressed",
+		Noun:         "audio file",
+		Compare:      true,
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeCompressionFailed,
 	}, func(file string) (*job.Job, error) {
 		ext := format.Ext(file)
 		if format.Classify(ext) != format.Audio {

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -24,6 +24,10 @@ type ImageOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 	// MaxEdge caps the longest edge in pixels; 0 keeps the dimensions.
 	MaxEdge int
 }
@@ -52,13 +56,16 @@ func Image(opts ImageOptions) error {
 	)
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Compressing",
-		Done:    "Compressed",
-		Noun:    "image file",
-		Compare: true,
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeCompressionFailed,
+		Verb:         "Compressing",
+		Done:         "Compressed",
+		Noun:         "image file",
+		Compare:      true,
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeCompressionFailed,
 	}, func(file string) (*job.Job, error) {
 		return planImage(file, quality, opts.MaxEdge, opts.OutputDir)
 	})

--- a/internal/compress/pdf.go
+++ b/internal/compress/pdf.go
@@ -18,6 +18,10 @@ type PDFOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 }
 
 // PDF compresses PDF files using Ghostscript.
@@ -46,13 +50,16 @@ func PDF(opts PDFOptions) error {
 	}
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Compressing",
-		Done:    "Compressed",
-		Noun:    "PDF file",
-		Compare: true,
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeCompressionFailed,
+		Verb:         "Compressing",
+		Done:         "Compressed",
+		Noun:         "PDF file",
+		Compare:      true,
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeCompressionFailed,
 	}, func(file string) (*job.Job, error) {
 		if format.Ext(file) != "pdf" {
 			return nil, derrors.Newf(

--- a/internal/compress/video.go
+++ b/internal/compress/video.go
@@ -19,6 +19,10 @@ type VideoOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 	// MaxEdge caps the longest edge in pixels; 0 keeps the resolution.
 	MaxEdge int
 }
@@ -44,13 +48,16 @@ func Video(opts VideoOptions) error {
 	)
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Compressing",
-		Done:    "Compressed",
-		Noun:    "video file",
-		Compare: true,
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeCompressionFailed,
+		Verb:         "Compressing",
+		Done:         "Compressed",
+		Noun:         "video file",
+		Compare:      true,
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeCompressionFailed,
 	}, func(file string) (*job.Job, error) {
 		ext := format.Ext(file)
 		if format.Classify(ext) != format.Video {

--- a/internal/convert/audio.go
+++ b/internal/convert/audio.go
@@ -20,6 +20,10 @@ type AudioOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 }
 
 // Audio converts audio files, or extracts the audio track of video files, to
@@ -47,12 +51,15 @@ func Audio(opts AudioOptions) error {
 	}
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Converting",
-		Done:    "Converted",
-		Noun:    "audio file",
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeConversionFailed,
+		Verb:         "Converting",
+		Done:         "Converted",
+		Noun:         "audio file",
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeConversionFailed,
 	}, func(file string) (*job.Job, error) {
 		ext := format.Ext(file)
 		if cat := format.Classify(ext); cat != format.Audio && cat != format.Video {

--- a/internal/convert/image.go
+++ b/internal/convert/image.go
@@ -22,6 +22,10 @@ type ImageOptions struct {
 	OutputDir string
 	InPlace   bool
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 	// MaxEdge caps the longest edge in pixels; 0 keeps the dimensions.
 	MaxEdge int
 }
@@ -50,12 +54,15 @@ func Image(opts ImageOptions) error {
 	)
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Converting",
-		Done:    "Converted",
-		Noun:    "image file",
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeConversionFailed,
+		Verb:         "Converting",
+		Done:         "Converted",
+		Noun:         "image file",
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeConversionFailed,
 	}, func(file string) (*job.Job, error) {
 		ext := format.Ext(file)
 		if format.Classify(ext) != format.Image {

--- a/internal/convert/pdf.go
+++ b/internal/convert/pdf.go
@@ -23,6 +23,10 @@ type PDFOptions struct {
 	Quality   string
 	OutputDir string
 	DryRun    bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 }
 
 // PDF converts PDFs to images or combines images into a PDF, chosen by the
@@ -69,11 +73,14 @@ func pdfToImages(opts PDFOptions, target string) error {
 	ui.Message.Infof("Converting PDF → .%s pages at %d DPI", target, dpi)
 
 	return job.Run(opts.Files, job.Options{
-		Verb:   "Extracting",
-		Done:   "Extracted",
-		Noun:   "PDF file",
-		DryRun: opts.DryRun,
-		Code:   derrors.CodeConversionFailed,
+		Verb:         "Extracting",
+		Done:         "Extracted",
+		Noun:         "PDF file",
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeConversionFailed,
 	}, func(file string) (*job.Job, error) {
 		if format.Ext(file) != "pdf" {
 			return nil, derrors.Newf(
@@ -150,11 +157,14 @@ func imagesToPDF(opts PDFOptions) error {
 	ui.Message.Infof("Combining %d images into %s", len(images), out)
 
 	return job.Run([]string{first}, job.Options{
-		Verb:   "Combining",
-		Done:   "Combined",
-		Noun:   "PDF",
-		DryRun: opts.DryRun,
-		Code:   derrors.CodeConversionFailed,
+		Verb:         "Combining",
+		Done:         "Combined",
+		Noun:         "PDF",
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeConversionFailed,
 	}, func(string) (*job.Job, error) {
 		args := make([]string, 0, len(images)+1)
 		args = append(args, images...)

--- a/internal/convert/video.go
+++ b/internal/convert/video.go
@@ -25,6 +25,10 @@ type VideoOptions struct {
 	OutputDir  string
 	InPlace    bool
 	DryRun     bool
+	// Jobs, SkipExisting and Backup are passed through to job.Options.
+	Jobs         int
+	SkipExisting bool
+	Backup       bool
 	// MaxEdge caps the longest edge in pixels; it always implies a re-encode.
 	MaxEdge int
 }
@@ -57,12 +61,15 @@ func Video(opts VideoOptions) error {
 	)
 
 	return job.Run(opts.Files, job.Options{
-		Verb:    "Converting",
-		Done:    "Converted",
-		Noun:    "video file",
-		InPlace: opts.InPlace,
-		DryRun:  opts.DryRun,
-		Code:    derrors.CodeConversionFailed,
+		Verb:         "Converting",
+		Done:         "Converted",
+		Noun:         "video file",
+		InPlace:      opts.InPlace,
+		DryRun:       opts.DryRun,
+		Jobs:         opts.Jobs,
+		SkipExisting: opts.SkipExisting,
+		Backup:       opts.Backup,
+		Code:         derrors.CodeConversionFailed,
 	}, func(file string) (*job.Job, error) {
 		ext := format.Ext(file)
 		if format.Classify(ext) != format.Video {

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -12,12 +12,14 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"time"
 
 	"charm.land/log/v2"
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
 	"github.com/y3owk1n/uts/internal/format"
 	"github.com/y3owk1n/uts/internal/ui"
+	"github.com/y3owk1n/uts/internal/ui/message"
 	"github.com/y3owk1n/uts/internal/util"
 )
 
@@ -87,128 +89,248 @@ type Options struct {
 	Compare bool
 	InPlace bool
 	DryRun  bool
+	// Jobs is how many files run at once. Values below 2 run sequentially.
+	Jobs int
+	// SkipExisting leaves a file alone when its output already exists, so an
+	// interrupted batch can be re-run without redoing finished files.
+	SkipExisting bool
+	// Backup keeps the original as <name>.bak when InPlace replaces it.
+	Backup bool
 	// Code is the error code returned when any file fails.
 	Code derrors.Code
+}
+
+type outcome int
+
+const (
+	outcomeDone outcome = iota
+	outcomeFailed
+	outcomeSkipped
+)
+
+type result struct {
+	outcome outcome
+	saved   int64
+}
+
+type runner struct {
+	opts  Options
+	plan  func(string) (*Job, error)
+	total int
 }
 
 // Run plans and executes one job per file. It never stops at the first
 // failure; every file gets its turn and an error summarizing the failures is
 // returned at the end so the CLI exits non-zero.
 func Run(files []string, opts Options, plan func(file string) (*Job, error)) error {
-	total := len(files)
+	runner := &runner{opts: opts, plan: plan, total: len(files)}
+
+	var results []result
+	if opts.Jobs > 1 && !opts.DryRun && len(files) > 1 {
+		results = runner.parallel(files)
+	} else {
+		results = runner.sequential(files)
+	}
 
 	var done, failed, skipped int
 
 	var saved int64
 
-	for idx, file := range files {
-		if !util.FileExists(file) {
-			ui.Message.Warnf("File not found: %s", file)
-
-			failed++
-
-			continue
-		}
-
-		job, err := plan(file)
-		if err != nil {
-			ui.Message.Errorf("%s: %v", file, err)
-
-			failed++
-
-			continue
-		}
-
-		if job.Skip != "" {
-			ui.Message.Warnf("%s, skipping: %s", job.Skip, file)
-
-			skipped++
-
-			continue
-		}
-
-		origSize := util.FileSize(file)
-		ui.Message.Stepf("[%d/%d] %s (%s)", idx+1, total, file, util.HumanSize(origSize))
-
-		if job.Note != "" {
-			ui.Message.Mutedf("  %s", job.Note)
-		}
-
-		if opts.DryRun {
-			preview(job, opts.InPlace)
-
+	for _, res := range results {
+		switch res.outcome {
+		case outcomeDone:
 			done++
-
-			continue
-		}
-
-		err = execute(job, opts)
-		if err != nil {
-			ui.Message.Errorf("%s failed: %s", strings.TrimSuffix(opts.Verb, "ing")+"ion", file)
-			ui.Message.Mutedf("%s", err)
-
+			saved += res.saved
+		case outcomeFailed:
 			failed++
-
-			continue
+		case outcomeSkipped:
+			skipped++
 		}
-
-		newSize := util.FileSize(job.Output)
-
-		switch {
-		case opts.Compare:
-			ui.Message.Successf("%s: %s → %s %s", file, util.HumanSize(origSize),
-				util.HumanSize(newSize), util.CompressionRatio(origSize, newSize))
-
-			if newSize >= origSize {
-				ui.Message.Warnf("Result is not smaller than the original, keeping %s", file)
-
-				if opts.InPlace {
-					_ = os.Remove(job.Output)
-				}
-
-				skipped++
-
-				continue
-			}
-
-			saved += origSize - newSize
-		case isDir(job.Output):
-			ui.Message.Successf("%s → %s/", file, job.Output)
-		default:
-			ui.Message.Successf("%s → %s (%s)", file, job.Output, util.HumanSize(newSize))
-		}
-
-		if opts.InPlace {
-			replaceInPlace(job)
-		}
-
-		done++
 	}
 
-	if total > 1 {
+	if runner.total > 1 {
 		summarize(opts, done, failed, skipped, saved)
 	}
 
 	if failed > 0 {
-		return derrors.Newf(opts.Code, "%d of %d files failed", failed, total)
+		return derrors.Newf(opts.Code, "%d of %d files failed", failed, runner.total)
 	}
 
 	return nil
 }
 
-func preview(job *Job, inPlace bool) {
-	ui.Message.Infof("[dry-run] Would write %s%s", job.Output, util.InPlaceHint(inPlace))
+func (r *runner) sequential(files []string) []result {
+	results := make([]result, 0, len(files))
+
+	for idx, file := range files {
+		results = append(results, r.process(idx, file, ui.Message, ui.NewSpinner(nil, 0)))
+	}
+
+	return results
+}
+
+// parallel runs up to opts.Jobs files at once. Each file's messages are
+// buffered and flushed when it finishes so lines never interleave, and one
+// spinner tracks overall progress.
+func (r *runner) parallel(files []string) []result {
+	results := make([]result, len(files))
+	sem := make(chan struct{}, r.opts.Jobs)
+
+	var (
+		workers   sync.WaitGroup
+		flush     sync.Mutex
+		completed int
+	)
+
+	spinner := ui.NewSpinner(nil, 0)
+	spinner.SetSuffix(
+		fmt.Sprintf("%s %d files, %d at a time...", r.opts.Verb, len(files), r.opts.Jobs),
+	)
+	spinner.Start()
+
+	for idx, file := range files {
+		workers.Go(func() {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+
+			var out, errOut bytes.Buffer
+
+			res := r.process(idx, file, ui.Message.WithWriters(&out, &errOut), nil)
+
+			flush.Lock()
+			defer flush.Unlock()
+
+			results[idx] = res
+			completed++
+
+			spinner.Stop()
+
+			_, _ = os.Stdout.Write(out.Bytes())
+			_, _ = os.Stderr.Write(errOut.Bytes())
+
+			if completed < len(files) {
+				spinner.SetSuffix(fmt.Sprintf("%s %d/%d files, %d at a time...",
+					r.opts.Verb, completed, len(files), r.opts.Jobs))
+				spinner.Start()
+			}
+		})
+	}
+
+	workers.Wait()
+	spinner.Stop()
+
+	return results
+}
+
+// process handles one file and reports through printer. spinner is nil when the
+// caller shows its own progress.
+func (r *runner) process(
+	idx int,
+	file string,
+	printer *message.Printer,
+	spinner *ui.Spinner,
+) result {
+	opts := r.opts
+
+	if !util.FileExists(file) {
+		printer.Warnf("File not found: %s", file)
+
+		return result{outcome: outcomeFailed}
+	}
+
+	job, err := r.plan(file)
+	if err != nil {
+		printer.Errorf("%s: %v", file, err)
+
+		return result{outcome: outcomeFailed}
+	}
+
+	if job.Skip != "" {
+		printer.Warnf("%s, skipping: %s", job.Skip, file)
+
+		return result{outcome: outcomeSkipped}
+	}
+
+	if opts.SkipExisting && !opts.DryRun && outputExists(job) {
+		printer.Warnf("Output exists, skipping: %s", job.Output)
+
+		return result{outcome: outcomeSkipped}
+	}
+
+	origSize := util.FileSize(file)
+	printer.Stepf("[%d/%d] %s (%s)", idx+1, r.total, file, util.HumanSize(origSize))
+
+	if job.Note != "" {
+		printer.Mutedf("  %s", job.Note)
+	}
+
+	if opts.DryRun {
+		preview(printer, job, opts.InPlace)
+
+		return result{outcome: outcomeDone}
+	}
+
+	err = execute(job, opts, spinner)
+	if err != nil {
+		printer.Errorf("%s failed: %s", strings.TrimSuffix(opts.Verb, "ing")+"ion", file)
+		printer.Mutedf("%s", err)
+
+		return result{outcome: outcomeFailed}
+	}
+
+	newSize := util.FileSize(job.Output)
+
+	var saved int64
+
+	switch {
+	case opts.Compare:
+		printer.Successf("%s: %s → %s %s", file, util.HumanSize(origSize),
+			util.HumanSize(newSize), util.CompressionRatio(origSize, newSize))
+
+		if newSize >= origSize {
+			printer.Warnf("Result is not smaller than the original, keeping %s", file)
+
+			if opts.InPlace {
+				_ = os.Remove(job.Output)
+			}
+
+			return result{outcome: outcomeSkipped}
+		}
+
+		saved = origSize - newSize
+	case isDir(job.Output):
+		printer.Successf("%s → %s/", file, job.Output)
+	default:
+		printer.Successf("%s → %s (%s)", file, job.Output, util.HumanSize(newSize))
+	}
+
+	if opts.InPlace {
+		replaceInPlace(job, opts.Backup)
+	}
+
+	return result{outcome: outcomeDone, saved: saved}
+}
+
+// outputExists reports whether a job's file output is already on disk.
+// Directory outputs (extracted archives, PDF pages) are never "existing"
+// because the directory is shared between inputs.
+func outputExists(job *Job) bool {
+	return job.Output != job.Input && util.FileExists(job.Output) && !isDir(job.Output)
+}
+
+func preview(printer *message.Printer, job *Job, inPlace bool) {
+	printer.Infof("[dry-run] Would write %s%s", job.Output, util.InPlaceHint(inPlace))
 
 	for _, step := range job.Steps {
 		if step.Cmd != nil {
-			ui.Message.Mutedf("  $ %s", util.Describe(step.Cmd))
+			printer.Mutedf("  $ %s", util.Describe(step.Cmd))
 		} else {
-			ui.Message.Mutedf("  %s", step.Desc)
+			printer.Mutedf("  %s", step.Desc)
 		}
 	}
 }
 
-func execute(job *Job, opts Options) error {
+func execute(job *Job, opts Options, spinner *ui.Spinner) error {
 	err := util.EnsureDir(job.Output)
 	if err != nil {
 		return fmt.Errorf("create output directory: %w", err)
@@ -216,26 +338,21 @@ func execute(job *Job, opts Options) error {
 
 	existed := util.FileExists(job.Output)
 
-	spinner := ui.NewSpinner(nil, 0)
-	spinner.SetSuffix(fmt.Sprintf("%s %s...", opts.Verb, job.Input))
-	spinner.Start()
+	if spinner != nil {
+		spinner.SetSuffix(fmt.Sprintf("%s %s...", opts.Verb, job.Input))
+		spinner.Start()
 
-	defer spinner.Stop()
+		defer spinner.Stop()
+	}
 
 	started := time.Now()
 	report := func(done, total float64) {
-		if total <= 0 {
+		if total <= 0 || spinner == nil {
 			return
 		}
 
-		spinner.SetSuffix(
-			fmt.Sprintf(
-				"%s %s... %s",
-				opts.Verb,
-				job.Input,
-				progressText(done, total, time.Since(started)),
-			),
-		)
+		spinner.SetSuffix(fmt.Sprintf("%s %s... %s", opts.Verb, job.Input,
+			progressText(done, total, time.Since(started))))
 	}
 
 	for _, step := range job.Steps {
@@ -378,8 +495,12 @@ func removeFile(path string) {
 
 // replaceInPlace makes the output take the original's place. Same-format
 // results overwrite the original; format-changing results delete the original
-// and take its base name.
-func replaceInPlace(job *Job) {
+// and take its base name. With backup the original survives as <name>.bak.
+func replaceInPlace(job *Job, backup bool) {
+	if backup {
+		_ = os.Rename(job.Input, job.Input+".bak")
+	}
+
 	if format.Same(format.Ext(job.Output), format.Ext(job.Input)) {
 		util.MaybeInPlace(job.Output, job.Input)
 

--- a/internal/ui/message/message.go
+++ b/internal/ui/message/message.go
@@ -47,6 +47,16 @@ type Printer struct {
 	afterError bool
 }
 
+// WithWriters returns a copy of the printer that writes elsewhere, keeping
+// palette, icons and quiet mode. Parallel jobs use it to buffer their output.
+func (pr *Printer) WithWriters(out, errOut io.Writer) *Printer {
+	clone := *pr
+	clone.out = out
+	clone.errOut = errOut
+
+	return &clone
+}
+
 // SetQuiet suppresses everything except warnings and errors.
 func (pr *Printer) SetQuiet(quiet bool) {
 	pr.quiet = quiet


### PR DESCRIPTION
This PR makes large batches fast and safe to re-run, and gives `--in-place` an undo.

## What changed

- **`-j N` / `--jobs N`** processes N files at once; `-j 0` uses one worker per CPU core. Each file's messages are buffered and printed together when it finishes, so output never interleaves, and a single spinner shows `Compressing 3/12 files, 4 at a time...`. Six 800x600 PNGs through pngquant went from serial to 1.5 s at 340% CPU with `-j 4`. It helps image, audio and PDF batches most; a single ffmpeg encode already uses every core. Default stays `1`, so existing behaviour is unchanged.
- **`--skip-existing`** leaves a file alone when its output is already on disk. Re-running the same command after an interruption only processes what is left. Directory outputs (archive extraction, PDF pages) are never treated as existing because they are shared between inputs.
- **`--backup`** keeps the original as `<name>.bak` when `--in-place` replaces it, for both same-format compression and format-changing conversion. Using it without `-i` prints a warning.
- Invalid `-j` values are rejected with a clear message; failures inside parallel runs still exit 1.

Internally the runner now has one per-file `process` step shared by the sequential and parallel paths, and the message printer can be cloned onto a buffer while keeping styling and quiet mode.

Docs: CLI reference gains the three flags in Global Options plus Resuming and Parallelism notes under Output Behavior; README gains a "Big batches" bullet.

## Why

A folder of 500 PNGs ran one at a time on one core, and a failure halfway meant redoing everything. `-i` was the only irreversible operation in the tool.

## How to test

```bash
just lint && just test-all
uts image compress ./photos -r -j 0
uts image compress ./photos -r --skip-existing      # "Output exists, skipping" for finished files
uts video compress clip.mp4 -i --backup; ls clip.mp4*  # clip.mp4 and clip.mp4.bak
uts image compress x.png -j -3; echo $?             # error, exit 1
```