### PR TITLE
fix(image): treat PNGs pngquant cannot improve as not smaller, not failed

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -151,6 +151,8 @@ uts image compress photo.heic -q low
 uts image compress ./photos --max 2000 -r
 ```
 
+A PNG that pngquant cannot shrink further (typically one it already quantized) is not a failure: the pixels are kept, optipng still runs its lossless pass, and the file is reported as not smaller.
+
 Conversion handles format shifting (e.g. modern formatting like `avif` or `webp`):
 
 ```bash

--- a/internal/compress/image.go
+++ b/internal/compress/image.go
@@ -2,8 +2,12 @@
 package compress
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"os/exec"
 	"strconv"
+	"strings"
 
 	derrors "github.com/y3owk1n/uts/internal/core/errors"
 	"github.com/y3owk1n/uts/internal/format"
@@ -110,10 +114,24 @@ func planImage(file string, quality, maxEdge int, outputDir string) (*job.Job, e
 
 // pngSteps compresses a PNG. With a size cap ImageMagick writes the resized
 // file first and pngquant then quantizes it in place.
+// pngquant exit codes that mean "nothing to gain here", not failure.
+const (
+	// pngquantTooLowQuality: the result would fall below the --quality
+	// minimum, typically because the PNG is already quantized.
+	pngquantTooLowQuality = 99
+	// pngquantNotSmaller: --skip-if-larger found the output would be bigger.
+	pngquantNotSmaller = 98
+)
+
+// pngSteps compresses a PNG. With a size cap ImageMagick writes the resized
+// file first and pngquant then quantizes it in place.
 func pngSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {
 	switch {
 	case util.HasTool("pngquant"):
-		quant := fmt.Sprintf("--quality=%d-%d", max(quality-10, 0), quality)
+		common := []string{
+			fmt.Sprintf("--quality=%d-%d", max(quality-10, 0), quality),
+			"--speed", "1", "--strip", "--force", "--skip-if-larger",
+		}
 
 		var (
 			steps []job.Step
@@ -126,38 +144,12 @@ func pngSteps(file, out string, quality, maxEdge int) (string, []job.Step, error
 				return "", nil, err
 			}
 
-			steps = append(
-				steps,
-				resize,
-				job.Exec(
-					"pngquant",
-					quant,
-					"--speed",
-					"1",
-					"--strip",
-					"--force",
-					"--ext",
-					".png",
-					out,
-				),
-			)
+			steps = append(steps, resize,
+				pngquantStep(file, out, append(common, "--ext", ".png", out), true))
 			tool = "ImageMagick + pngquant"
 		} else {
-			steps = append(
-				steps,
-				job.Exec(
-					"pngquant",
-					quant,
-					"--speed",
-					"1",
-					"--strip",
-					"--force",
-					"--output",
-					out,
-					"--",
-					file,
-				),
-			)
+			steps = append(steps,
+				pngquantStep(file, out, append(common, "--output", out, "--", file), false))
 			tool = "pngquant"
 		}
 
@@ -177,6 +169,34 @@ func pngSteps(file, out string, quality, maxEdge int) (string, []job.Step, error
 	}
 
 	return magickSteps(file, out, quality, maxEdge)
+}
+
+// pngquantStep runs pngquant and treats its "cannot improve this file" exit
+// codes as success rather than failure. The pixels are kept as they are:
+// when staged, out already holds the resized image; otherwise the input is
+// copied to out. optipng can still do lossless work on it and the runner's
+// not-smaller guard reports the outcome.
+func pngquantStep(file, out string, args []string, staged bool) job.Step {
+	cmd := exec.CommandContext(context.Background(), "pngquant", args...)
+
+	return job.Do(util.Describe(cmd), func() error {
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) &&
+			(exitErr.ExitCode() == pngquantTooLowQuality || exitErr.ExitCode() == pngquantNotSmaller) {
+			if staged {
+				return nil
+			}
+
+			return util.CopyFile(file, out)
+		}
+
+		return fmt.Errorf("pngquant: %w\n%s", err, strings.TrimSpace(string(output)))
+	})
 }
 
 func jpegSteps(file, out string, quality, maxEdge int) (string, []job.Step, error) {


### PR DESCRIPTION
This PR stops `uts image compress` from reporting a failure on PNGs that pngquant has nothing left to squeeze out of.

## What changed

- pngquant exits 99 when the result would fall below the requested `--quality` minimum, which is exactly what happens to a PNG it already quantized. `uts` reported `Compression failed: pngquant: exit status 99` and exited 1, so re-running a batch over its own output looked broken.
- pngquant now runs with `--skip-if-larger`, and exit codes 98 and 99 are treated as "nothing to gain": the pixels are kept (the resized file when `--max` is set, otherwise a copy of the input), optipng still runs its lossless pass, and the existing not-smaller guard reports the file and keeps the original. The command exits 0.
- Any other pngquant failure is still an error with pngquant's output attached, and `--dry-run` still shows the pngquant command.

Docs: one sentence in the CLI reference under image compression.

## Why

Found while testing `--skip-existing`: a second pass over a folder containing earlier `-small.png` results failed 5 of 13 files for no user-visible reason.

## How to test

```bash
just lint && just test-all
uts image compress photo.png -q low                 # photo-small.png
uts image compress photo-small.png -q low; echo $?  # "not smaller, keeping", exit 0
uts image compress photo-small.png --max 400        # still resizes and shrinks
```